### PR TITLE
Run conda install in quiet mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ before_install:
   - source install-miniconda.sh
   - conda update --yes conda
   # Install dependencies
-  - conda install --yes python=3.6 pip -c conda-forge
+  - conda install --yes python=3.6 pip -c conda-forge --quiet
   # Need the dev channel to get development builds of GMT 6
-  - conda install --yes --file requirements.txt -c conda-forge/label/dev -c conda-forge
-  - conda install --yes --file requirements-dev.txt -c conda-forge
+  - conda install --yes --file requirements.txt -c conda-forge/label/dev -c conda-forge --quiet
+  - conda install --yes --file requirements-dev.txt -c conda-forge --quiet
   # Show installed pkg information for postmortem diagnostic
   - conda list
   #- if [ `uname` = "Darwin" ]; then

--- a/install-miniconda.sh
+++ b/install-miniconda.sh
@@ -18,6 +18,9 @@ chmod +x miniconda.sh
 
 export PATH=$CONDA_PREFIX/bin:$PATH
 
+# So that we can find libgmt
+export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
+
 # Workaround for https://github.com/travis-ci/travis-ci/issues/6522
 # Turn off exit on failure.
 set +e


### PR DESCRIPTION
Trying to avoid a BlockingIOError in the TravisCI build. Seems to be related to stdout printing.
Curiously doesn't happen on GMT/Python.

@joa-quim I'm trying out some fixes. It might be something with the julia Travis environment. I'm using a language agnostic one for GMT/Python since I get Python from conda-forge anyway.