### PR TITLE
Install GMT binary with BinDeps.jl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 docs/build/
 docs/site/
+deps/deps.jl

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+BinDeps

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,11 @@
+using BinDeps
+
+@BinDeps.setup
+
+libgmt = library_dependency("libgmt")
+
+# package managers
+provides(AptGet, "gmt", libgmt)
+provides(Pacman, "gmt", libgmt)
+
+@BinDeps.install Dict(:libgmt => :libgmt)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,7 +5,14 @@ using BinDeps
 libgmt = library_dependency("libgmt")
 
 # package managers
-provides(AptGet, "gmt", libgmt)
 provides(Pacman, "gmt", libgmt)
+
+if is_apple()
+    if Pkg.installed("Homebrew") === nothing
+        error("Homebrew package not installed, please run Pkg.add(\"Homebrew\")")
+    end
+    using Homebrew
+    provides(Homebrew.HB, "gmt", libgmt)
+end
 
 @BinDeps.install Dict(:libgmt => :libgmt)


### PR DESCRIPTION
This PR uses the BinDeps.jl package to install the GMT binary when it is not installed already.

Feel free to add more providers for MacOS or a source provider to build a particular version of GMT from the sources.