### PR TITLE
Redirect base URL to latest docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="Refresh" content="0;url=latest/"/>


### PR DESCRIPTION
The `index.html` file redirects the base URL to the `latest/` folder so
That `https://genericmappingtools.github.io/GMT.jl` goes there instead
of ending in a 404.
Add the `.nojekyll` file so that Github knows not to try to compile the
sources in the `gh-pages` branch using Jekyll (a static site generator).