### PR TITLE
Fix color parsing, but break slightly previous behavior.

### DIFF
--- a/docs/src/color.md
+++ b/docs/src/color.md
@@ -8,17 +8,22 @@ symbols, etc and the one documented here.
 
 We may use this in modules that expect the *color* or *fill* keywords, then the value can be a string or a
 symbol with the color's name (or names separated by commas); a number in the [0 255] range to indicate a
-gray shade tone; or a 3-elements tuple or array where each element contains the R,G,B component in either
-[0 255] or [0 1] range.
+gray shade tone; or a 3-elements tuple (more tricky) or array (simpler) where each element contains the
+R,G,B component in either [0 255] or [0 1] range.
 
 Examples:
 
-- *color=:red*
-- *color=200*
-- *color="30/20/180"*
-- *color=(30,20,180)*
-- *color=[0.118 0.078 0.706]*
-- *color=:red,:green,:blue*
+- *color=:red*                     Single color
+- *color=200*                      Single gray
+- *color="#aabbcc"*                Single color
+- *color="30/20/180"*              Single color
+- *color="yellow,brown"*           Two colors
+- *color=(30,180)*                 Two gray levels
+- *color=((30,20,180),)*           Single color
+- *color=((10,50,99),(20,60,90))*  Two colors
+- *color=[0.118 0.078 0.706]*      Single color in [0 1]
+- *color=[10 50 99; 20 60 90]*     Two colors
+- *color=(:red,:green,:blue)*      Three colors
 
 But there are other options that expect color in one of its elements. For example, to set a text font we
 may want to choose a color (i.e. not use the default which is black). Then we would do drop the *color=*

--- a/src/common_options.jl
+++ b/src/common_options.jl
@@ -1084,13 +1084,22 @@ function get_color(val)
 	# color1,color2[,color3,…] colorn can be a r/g/b triplet, a color name, or an HTML hexadecimal color (e.g. #aabbcc
 	if (isa(val, String) || isa(val, Symbol) || isa(val, Number))  return string(val)  end
 
-	if (isa(val, Tuple) && (length(val) == 3))
-		if (val[1] <= 1 && val[2] <= 1 && val[3] <= 1)		# Assume colors components are in [0 1]
-			return @sprintf("%d/%d/%d", val[1]*255, val[2]*255, val[3]*255)
-		else
-			return @sprintf("%d/%d/%d", val[1], val[2], val[3])
+	out = ""
+	if (isa(val, Tuple))
+		for k = 1:length(val)
+			if (isa(val[k], Tuple) && (length(val[k]) == 3))
+				s = 1
+				if (val[k][1] <= 1 && val[k][2] <= 1 && val[k][3] <= 1)  s = 255  end	# colors in [0 1]
+				out *= @sprintf("%d/%d/%d,", val[k][1]*s, val[k][2]*s, val[k][3]*s)
+			elseif (isa(val[k], Symbol) || isa(val[k], String) || isa(val[k], Number))
+				out *= string(val[k],",")
+			else
+				error("Color tuples must have only one or three elements")
+			end
 		end
-	elseif (isa(val, Array) && (size(val, 2) == 3))
+		out = rstrip(out, ',')		# Strip last ','``
+	elseif ((isa(val, Array) && (size(val, 2) == 3)) || (isa(val, Vector) && length(val) == 3))
+		if (isa(val, Vector))  val = val'  end
 		if (val[1,1] <= 1 && val[1,2] <= 1 && val[1,3] <= 1)
 			copy = val .* 255		# Do not change the original
 		else
@@ -1100,10 +1109,10 @@ function get_color(val)
 		for k = 2:size(copy, 1)
 			out = @sprintf("%s,%d/%d/%d", out, copy[k,1], copy[k,2], copy[k,3])
 		end
-		return out
 	else
-		error(@sprintf("GOT_COLOR, got and unsupported data type: %s", typeof(val)))
+		error(@sprintf("GOT_COLOR, got an unsupported data type: %s", typeof(val)))
 	end
+	return out
 end
 
 # ---------------------------------------------------------------------------------------------------

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,18 +75,21 @@ if (got_it)					# Otherwise go straight to end
 	@test GMT.opt_pen(Dict(:lw => 5),'W', nothing) == " -W5"
 	@test GMT.opt_pen(Dict(:a => (10,:red)),'W', [:a]) == " -W10,red"
 	@test_throws ErrorException("Nonsense in W option") GMT.opt_pen(Dict(:a => [1 2]),'W', [:a])
-	@test GMT.get_color((1,2,3)) == "1/2/3"
-	@test GMT.get_color((0.1,0.2,0.3)) == "26/51/77"
+	@test GMT.get_color(((1,2,3),)) == "1/2/3"
+	@test GMT.get_color(((0.1,0.2,0.3),)) == "26/51/77"
 	@test GMT.get_color([1 2 3]) == "1/2/3"
 	@test GMT.get_color([0.4 0.5 0.8; 0.1 0.2 0.7]) == "102/26/128,26/51/179"
 	@test GMT.get_color([1 2 3; 3 4 5; 6 7 8]) == "1/3/6,3/4/5,6/7/8"
 	@test GMT.get_color(:red) == "red"
-	@test_throws ErrorException("GOT_COLOR, got and unsupported data type: Tuple{Int64,Int64}") GMT.get_color((1,2))
+	@test GMT.get_color((:red,:blue)) == "red,blue"
+	@test GMT.get_color((200,300)) == "200,300"
+	@test_throws ErrorException("GOT_COLOR, got an unsupported data type: Array{Int64,1}") GMT.get_color([1,2])
+	@test_throws ErrorException("Color tuples must have only one or three elements") GMT.get_color(((0.2,0.3),))
 	@test GMT.parse_unit_unit("data") == "u"
 	@test GMT.parse_units((2,:p)) == "2p"
 	@test GMT.add_opt((a=(1,0.5),b=2), (a="+a",b="-b")) == "+a1/0.5-b2"
 	@test GMT.add_opt((symb=:circle, size=7, unit=:point), (symb="1", size="", unit="1")) == "c7p"
-	r = GMT.add_opt_fill("", Dict(:G=>(inv_pattern=12,fg="white",bg=(1,2,3), dpi=10) ), [:G :fill], 'G');
+	r = GMT.add_opt_fill("", Dict(:G=>(inv_pattern=12,fg="white",bg=[1,2,3], dpi=10) ), [:G :fill], 'G');
 	@test r == " -GP12+b1/2/3+fwhite+r10"
 	@test GMT.add_opt_fill("", Dict(:G=>:red), [:G :fill], 'G') == " -Gred"
 	@test_throws ErrorException("For 'fill' option as a NamedTuple, you MUST provide a 'patern' member") GMT.add_opt_fill("", Dict(:G=>(inv_pat=12,fg="white")), [:G], 'G')
@@ -115,7 +118,7 @@ if (got_it)					# Otherwise go straight to end
 	r = text(text_record([0 0], "TopLeft"), R="1/10/1/10", J=:X10, F=(region_justify=:MC,font=("10p","Times", :red)), Vd=:cmd);
 	ind = findfirst("-F", r); @test GMT.strtok(r[ind[1]:end])[1] == "-F+cMC+f10p,Times,red"
 
-	@test GMT.build_pen(Dict(:lw => 1, :lc => (1,2,3))) == "1,1/2/3"
+	@test GMT.build_pen(Dict(:lw => 1, :lc => [1,2,3])) == "1,1/2/3"
 	@test GMT.parse_pen((0.5, [1 2 3])) == "0.5,1/2/3"
 
 	@test GMT.helper0_axes((:left_full, :bot_full, :right_ticks, :top_bare, :up_bare)) == "WSetu"


### PR DESCRIPTION
This *color=(1,2,3)* now means three gray levels **-C1,2,3**