### PR TITLE
Disp in jupyter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GMT"
 uuid = "5752ebe1-31b9-557e-87aa-f909b540aa54"
 authors = ["Joaquim Luis <jluis@ualg.pt>"]
-version = "0.13.1"
+version = "0.14.0"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -28,11 +28,15 @@ happens with the output image file. By not directly specifying any format we are
 output image format which is PostScript (actually, except for *grdimage -A*, the only
 format that *GMT* can write). But we can select other formats by using the *fmt* keyword, for example
 *fmt="jpg"*, or *fmt=:png* or *fmt=:pdf*. In such cases, the *ghostscript* program (you need to have
-it installed) will take care of converting the *ps* file into the selected format. Note that we used
-either strings ("") or symbols (:) to represent the format. Here the rule is we can use symbols for
-any string argument that can be safely written as a symbol. Example, this is valid =:abc, but this
-is not =:+a (apparently parser will try to add to *a*). The use of symbols may be preferred for a
-question of laziness (less typing).
+it installed) will take care of converting the *ps* file into the selected format.
+
+When runing from Jupyter notebooks one does not need to worry about the image format. In fact the only
+allowed is *png* but that is taken care automatically, meaning that any *fmt=xxx* will be ignored.
+
+Note that we used either strings ("") or symbols (:) to represent the format. Here the rule is we can use
+symbols for any string argument that can be safely written as a symbol. Example, this is valid =:abc,
+but this is not =:+a (apparently parser will try to add to *a*). The use of symbols may be preferred for
+a question of laziness (less typing).
 
 The above example, however, does not use any input data (*coast* knows how to find its own data). One
 way of providing it to modules that work on them is to send in a file name with the data to operate on.
@@ -168,7 +172,7 @@ Actually, the default format is chosen by the contents of the global **FMT** var
 the *GMT.jl* file. Eventually this will evolve to using an environment variable but for the moment users
 will have to edit that file to set a different default format.
 
-A very interesting alternative is to set **FMT=""**, that is to not specify any image format. This will
+An interesting alternative is to set **FMT=""**, that is to not specify any image format. This will
 result in *NOT* saving any file on disk but to keep the PS figure internally stored in the program's memory. 
 In other words, the figure is built and kept in memory only. This allows converting to another format
 directly without the use of an intermediary disk file. The conversion is performed by the *psconvert* *GMT*
@@ -179,7 +183,7 @@ module that would be used like this (to convert to PDF):
 The issue with this solution, that could be implemented internally without user intervention, is that it
 currently only works on Windows.
 
-Another interesting alternative to a file format is the option to create RGB images with *psconvert* and
+Another alternative to a file format is the option to create RGB images with *psconvert* and
 return it to Julia as a [Image type](@ref) type.
 
     I = psconvert(in_memory=true, adjust=true)

--- a/src/GMT.jl
+++ b/src/GMT.jl
@@ -154,12 +154,12 @@ end
 function __init__()
 	try
 		ver = Meta.parse(readlines(`gmt --version`)[1][1:3])
-		if (ver != GMTver && abs(ver - GNTver) > 0.5)	# Warn only when detecting a GMT5 vs GMT6 change
+		if (ver != GMTver && abs(ver - GMTver) > 0.5)	# Warn only when detecting a GMT5 vs GMT6 change
+			t = joinpath(homedir(), ".julia", "compiled", "v1.xxx", "GMT")
 			println("\n\tYou seem to have changed your installed GMT version. Current version")
 			println("\treports to be $ver but previously it was $GMTver. To fix this you need to")
 			println("\tmake sure that GMT.jl recompiles again, otherwise fatal errors may occur.")
-			t = joinpath(@__DIR__, "deps", "GMT.jl")
-			println("\tA dirty way to force that is to make an irrelevant change in (and revert it after)\n\t$t")
+			println("\tPlease delete the contents of the\n\n\t\t$t\n\n\tdirectory and start a new Julia session.")
 		end
 	catch
 	end

--- a/src/common_options.jl
+++ b/src/common_options.jl
@@ -2291,12 +2291,13 @@ end
 function showfig(d::Dict, fname_ps::String, fname_ext::String, opt_T::String, K=false, fname="")
 	# Take a PS file, convert it with psconvert (unless opt_T == "" meaning file is PS)
 	# and display it in default system viewer
-	# FNAME_EXT hold the extension when not PS
+	# FNAME_EXT holds the extension when not PS
 	# OPT_T holds the psconvert -T option, again when not PS
 	# FNAME is for when using the savefig option
 
 	#global current_cpt = nothing		# Always reset to empty when fig is finalized
 	global current_view = nothing
+	if (isdefined(Main, :IJulia) && Main.IJulia.inited)	 opt_T = " -Tg"; fname_ext = "png"  end		# In Jupyter png only
 	if (opt_T != "")
 		if (K) gmt("psxy -T -R0/1/0/1 -JX1 -O >> " * fname_ps)  end		# Close the PS file first
 		if ((val = find_in_dict(d, [:dpi :DPI])[1]) !== nothing)  opt_T *= string(" -E", val)  end
@@ -2314,9 +2315,13 @@ function showfig(d::Dict, fname_ps::String, fname_ext::String, opt_T::String, K=
 	end
 
 	if (haskey(d, :show) && d[:show] != 0)
-		@static if (Sys.iswindows()) run(ignorestatus(`explorer $out`))
-		elseif (Sys.isapple()) run(`open $(out)`)
-		elseif (Sys.islinux() || Sys.isbsd()) run(`xdg-open $(out)`)
+		if (isdefined(Main, :IJulia) && Main.IJulia.inited)				# From Jupyter?
+			display("image/png", read(out))
+		else
+			@static if (Sys.iswindows()) run(ignorestatus(`explorer $out`))
+			elseif (Sys.isapple()) run(`open $(out)`)
+			elseif (Sys.islinux() || Sys.isbsd()) run(`xdg-open $(out)`)
+			end
 		end
 	end
 end

--- a/src/gmt2kml.jl
+++ b/src/gmt2kml.jl
@@ -67,7 +67,7 @@ Parameters
     Scale icons or labels. Here, S=:c sets a scale for the symbol icon, whereas S=:n sets
     a scale for the name labels
     ($(GMTdoc)gmt2kml.html#s)
-- **T** | **title ** :: [Type => Str]    ``Arg = title[/foldername]``
+- **T** | **title** :: [Type => Str]    ``Arg = title[/foldername]``
 
     Sets the document title [default is unset]. Optionally, append /FolderName;
     ($(GMTdoc)gmt2kml.html#t)


### PR DESCRIPTION
Now displays images in Jupyter notebooks and automatically selects *png* as image format.