### PR TITLE
Fix a bug left over when passing globals to const arrays. It was causing grids flip UD

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GMT"
 uuid = "5752ebe1-31b9-557e-87aa-f909b540aa54"
 authors = ["Joaquim Luis <jluis@ualg.pt>"]
-version = "0.15.0"
+version = "0.16.0"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/src/common_options.jl
+++ b/src/common_options.jl
@@ -1338,7 +1338,7 @@ function get_cpt_set_R(d::Dict, cmd0::String, cmd::String, opt_R::String, got_fn
 	if (isa(arg1, GMTgrid) || cmd0 != "")
 		if (current_cpt === nothing && (val = find_in_dict(d, [:C :color :cmap])[1]) === nothing)
 			# If no cpt name sent in, then compute (later) a default cpt
-			cpt_opt_T = @sprintf(" -T%.14g/%.14g/128+n", range[5], range[6])
+			cpt_opt_T = @sprintf(" -T%.16g/%.16g/128+n", range[5] - eps()*100, range[6] + eps()*100)
 		end
 		if (opt_R == "")
 			cmd *= @sprintf(" -R%.14g/%.14g/%.14g/%.14g", range[1], range[2], range[3], range[4])

--- a/src/gmt_main.jl
+++ b/src/gmt_main.jl
@@ -412,7 +412,7 @@ function get_grid(API::Ptr{Nothing}, object)
 	t = unsafe_wrap(Array, G.data, my * mx)
 	z = zeros(Float32, ny, nx)
 
-	if (isempty(grd_mem_layout))
+	if (grd_mem_layout[1] == "")
 		for col = 1:nx
 			for row = 1:ny
 				ij = GMT_IJP(row, col, mx, padTop, padLeft)		# This one is Int64


### PR DESCRIPTION

Increase decimals when auto-computing CPTs