### PR TITLE
subscript in docs

### DIFF
--- a/docs/src/gallery/historic/ex34.md
+++ b/docs/src/gallery/historic/ex34.md
@@ -8,6 +8,6 @@
     grdimage!("@FR+IT.nc", shade=(azim=15, norm="e0.75"), y_off=11,
               frame=(axes=:WsnE, annot=:auto, title="Franco-Italian Union, 2042-45"))
     coast!(DCW=(country="FR,IT", fill="red@60"), show=true)
-    ```
+```
 
 See also [`GMT ex34`](https://www.generic-mapping-tools.org/gmt/latest/gallery/ex34.html#example-34)

--- a/docs/src/gallery/historic/ex35.md
+++ b/docs/src/gallery/historic/ex35.md
@@ -15,6 +15,6 @@
     coast!(shore=1, land=:steelblue, area=(0,1,1),
            frame=(annot=30, grid=30, title="Distances from GSHHG crude coastlines"),
            show=true)
-    ```
+```
 
 See also [`GMT ex35`](https://www.generic-mapping-tools.org/gmt/latest/gallery/ex35.html#example-35)

--- a/docs/src/gallery/historic/ex36.md
+++ b/docs/src/gallery/historic/ex36.md
@@ -11,6 +11,6 @@
 	# Smoothing
 	Gtt = sphinterpolate("@mars370d.txt", region=:global, inc=1, tension=3, grid=true)
 	grdimage!(Gtt, frame=(annot=30, grid=30), y_off=-8,  show=1)
-    ```
+```
 
 See also [`GMT ex36`](https://www.generic-mapping-tools.org/gmt/latest/gallery/ex36.html#example-36)

--- a/src/project.jl
+++ b/src/project.jl
@@ -28,9 +28,9 @@ Parameters
 
     Generate mode. No input is read. Create (r, s, p) output points every dist units of p. See Q option.
     ($(GMTdoc)project.html#g)
-- **L** | **length_control** :: [Type => Number or list/tuple]    ``Arg = [w|l_min/l_max]``
+- **L** | **length_control** :: [Type => Number or list/tuple]    ``Arg = [w|l_{min}/l_{max}]``
 
-    Length controls. Project only those points whose p coordinate is within l_min < p < l_max.
+    Length controls. Project only those points whose p coordinate is within l\\_min < p < l\\_max.
     ($(GMTdoc)project.html#l)
 - **N** | **flat_earth** :: [Type => Bool or []]
 
@@ -48,9 +48,9 @@ Parameters
 
     px,py sets the position of the rotation pole of the projection. (Definition 3).
     ($(GMTdoc)project.html#t)
-- **W** | **width_control** :: [Type => list/tuple]    ``Arg = (w_min,w_max)``
+- **W** | **width_control** :: [Type => list/tuple]    ``Arg = (w_{min},w_{max})``
 
-    Width controls. Project only those points whose q coordinate is within w_min < q < w_max.
+    Width controls. Project only those points whose q coordinate is within w\\_min < q < w\\_max.
     ($(GMTdoc)project.html#w)
 
 - $(GMT.opt_write)


### PR DESCRIPTION
# Before:
<img width="845" alt="Screen Shot 2020-05-03 at 21 00 13" src="https://user-images.githubusercontent.com/17849322/80915526-656c8900-8d85-11ea-9981-4a73a33f620d.png">

# After
<img width="845" alt="Screen Shot 2020-05-03 at 21 27 45" src="https://user-images.githubusercontent.com/17849322/80915534-70271e00-8d85-11ea-97b0-2caf24dd43d9.png">

ref: [Documenter.jl](https://juliadocs.github.io/Documenter.jl/stable/man/latex/)