### PR TITLE
Avoid regression in psconvert from externals. Need to call gmt("destroy")

### DIFF
--- a/src/common_options.jl
+++ b/src/common_options.jl
@@ -2528,6 +2528,7 @@ function showfig(d::Dict, fname_ps::String, fname_ext::String, opt_T::String, K=
 	if (opt_T != "")
 		if (K) gmt("psxy -T -R0/1/0/1 -JX0.001 -O >> " * fname_ps)  end		# Close the PS file first
 		if ((val = find_in_dict(d, [:dpi :DPI])[1]) !== nothing)  opt_T *= string(" -E", val)  end
+		gmt("destroy")
 		gmt("psconvert -A1p -Qg4 -Qt4 " * fname_ps * opt_T)
 		out = fname_ps[1:end-2] * fname_ext
 		if (fname != "")

--- a/src/gmtreadwrite.jl
+++ b/src/gmtreadwrite.jl
@@ -147,9 +147,9 @@ end
 function guess_T_from_ext(fname::String)
 	# Guess the -T option from a couple of known extensions
 	fname, ext = splitext(fname)
-	if (ext == "")			# A SUBDATASET encoded fname?
-		if (occursin("nc=gd?", fname))  return " -Tg"
-		else                            return nothing
+	if (length(ext) >= 5)			# A SUBDATASET encoded fname?
+		if (occursin("?", ext))  return " -Tg"
+		else                     return nothing
 		end
 	end
 	ext = lowercase(ext[2:end])

--- a/src/subplot.jl
+++ b/src/subplot.jl
@@ -90,7 +90,7 @@ function subplot(fim=nothing; stop=false, kwargs...)
 
 		if (!IamModern[1])			# If we are not in modern mode, issue a gmt("begin") first
 			fname = ""				# Default name (GMTplot.ps) is set in gmt_main()
-			if ((val = find_in_dict(d, [:name :savefig])[1]) !== nothing)
+			if ((val = find_in_dict(d, [:figname :name :savefig])[1]) !== nothing)
 				fname = get_format(string(val), nothing, d)		# Get the fig name and format.
 			elseif ((val = find_in_dict(d, [:fmt])[1]) !== nothing)
 				fname = "GMTplot " * string(val)
@@ -124,10 +124,14 @@ function helper_sub_F(arg, dumb=nothing)
 	out = ""
 	if (isa(arg, String))
 		out = arg2str(arg)
-	elseif (isa(arg, NamedTuple) || isa(arg, Dict))
-		d = (isa(arg, NamedTuple)) ? nt2dict(arg) : arg
+	elseif (isa(arg, NamedTuple) || isa(arg, Dict) || isa(arg, Tuple{Tuple, Tuple}))
+		# Need first case because for example dims=(panels=((2,4),(2.5,5,1.25)),) shows up here only as
+		# arg = ((2, 4), (2.5, 5, 1.25)) because this function was called from within add_opt()
+		if (isa(arg, Tuple{Tuple, Tuple}))  d = Dict(:panels => arg)
+		else                                d = (isa(arg, NamedTuple)) ? nt2dict(arg) : arg
+		end
 		if ((val = find_in_dict(d, [:panels])[1]) !== nothing)
-			if (isa(val, Tuple{Tuple, Tuple}))		# ex: dim=(panels=((2,4),(2.5,5,1.25)),)
+			if (isa(val, Tuple{Tuple, Tuple}))		# ex: dims=(panels=((2,4),(2.5,5,1.25)),)
 				out *= arg2str(val[1], ',') * '/' * arg2str(val[2], ',')
 			else
 				out = arg2str(val)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -971,6 +971,7 @@ if (got_it)					# Otherwise go straight to end
 		@test endswith(subplot(grid=(1,1), limits="0/5/0/5", frame="west", F=("1i",2), Vd=dbg2), "-F1i/2")
 		@test endswith(subplot(grid=(1,1), limits="0/5/0/5", frame="west", F=(size=(1,2), frac=((2,3),(3,4,5))), figname="lixo.ps", Vd=dbg2), "-Ff1/2+f2,3/3,4,5")
 		@test endswith(subplot(grid=(1,1), limits="0/5/0/5", frame="west", F=(width=1,height=5,fwidth=(0.5,1),fheight=(10,), fill=:red, outline=(3,:red)), Vd=dbg2), "-F1/5+f0.5,1/10+gred+p3,red")
+		@test endswith(subplot(grid=(1,1), limits="0/5/0/5", frame="west", dims=(panels=((2,4),(2.5,5,1.25)),fill=:red), Vd=dbg2), "-Fs2,4/2.5,5,1.25+gred")
 		@test GMT.helper_sub_F((width=1,)) == "1/0"
 		#@test GMT.helper_sub_F((width=1,height=5,fwidth=(0.5,1),fheight=(10,))) == "1/5+f0.5,1/10"
 		@test_throws ErrorException("SUBPLOT: when using 'fwidth' must also set 'fheight'") GMT.helper_sub_F((width=1,height=5,fwidth=(0.5,1)))
@@ -979,7 +980,7 @@ if (got_it)					# Otherwise go straight to end
 		@test_throws ErrorException("SUBPLOT: 'grid' keyword is mandatory") subplot(F=("1i"), Vd=dbg2)
 		@test_throws ErrorException("Cannot call subplot(set, ...) before setting dimensions") subplot(:set, F=("1i"), Vd=dbg2)
 		println("    SUBPLOT2")
-		subplot(name="lixo", grid="1x1", limits="0/5/0/5", frame="west", F="s7/7", title="VERY VERY");subplot(:set, panel=(1,1));plot([0 0; 1 1]);subplot(:end)
+		subplot(name="lixo", fmt=:ps, grid="1x1", limits="0/5/0/5", frame="west", F="s7/7", title="VERY VERY");subplot(:set, panel=(1,1));plot([0 0; 1 1]);subplot(:end)
 		gmtbegin("lixo.ps");  gmtend()
 		gmtbegin("lixo", fmt=:ps);  gmtend()
 		gmtbegin("lixo");  gmtend()


### PR DESCRIPTION
This is a workaround fix. Final solution must come from GMT.