### PR TITLE
Update colorbar.md

### DIFF
--- a/docs/src/colorbar.md
+++ b/docs/src/colorbar.md
@@ -86,7 +86,7 @@ To plot a horizontal color scale (12 cm long; 0.5 cm wide) at the reference poin
 
 ```julia
     makecpt(range=(-200,1000,100), cmap=:rainbow)
-    colorbar(pos=(paper=true, anchor=(8,1), size=(12,0.5), justify=:TC, horizontal=true)
+    colorbar(pos=(paper=true, anchor=(8,1), size=(12,0.5), justify=:TC, horizontal=true),
             frame=(annot=:auto, ticks=:auto, xlabel="topography", ylabel=:km), show=true)
 ```
 


### PR DESCRIPTION
I think there are some problems with the second and third examples, but I can't figure out how to fix...


-----------
```julia
julia> colorbar(pos=(paper=true, anchor="6.5i", justify=(:LM,"2i"), size=(7.5,1.2), triangles=true),
                   cmap="colors.cpt", shade=true, xaxis(annot=5, label=:BATHYMETRY), ylabel=:m, show=1)
ERROR: UndefVarError: xaxis not defined
Stacktrace:
 [1] top-level scope at REPL[17]:1
```
```julia
colorbar(pos=(paper=true, anchor="6.5i", justify=(:LM,"2i"), size=(7.5,1.2), triangles=true),
                   cmap="colors.cpt", shade=true, xaxis=(annot=5, label=:BATHYMETRY), ylabel=:m, show=1)
psscale [WARNING]: GMT_Parse_Options: List interval-setting -B options before other axis -B options to ensure proper parsing.
psscale [WARNING]: Axis sub-item f set more than once (typo?)
psscale [WARNING]: Axis sub-item a set more than once (typo?)
ERROR: Something went wrong when calling the module. GMT error number = 71
Stacktrace:
 [1] error(::String, ::Int32) at ./error.jl:42
 [2] gmt(::String, ::Nothing) at /Users/t/.julia/packages/GMT/fZQQL/src/gmt_main.jl:246
 [3] finish_PS_module(::Dict{Symbol,Any}, ::String, ::String, ::Bool, ::Bool, ::Bool, ::Nothing) at /Users/t/.julia/packages/GMT/fZQQL/src/common_options.jl:2701
 [4] colorbar(::String, ::Nothing; first::Bool, kwargs::Base.Iterators.Pairs{Symbol,Any,NTuple{6,Symbol},NamedTuple{(:pos, :cmap, :shade, :xaxis, :ylabel, :show),Tuple{NamedTuple{(:paper, :anchor, :justify, :size, :triangles),Tuple{Bool,String,Tuple{Symbol,String},Tuple{Float64,Float64},Bool}},String,Bool,NamedTuple{(:annot, :label),Tuple{Int64,Symbol}},Symbol,Int64}}}) at /Users/t/.julia/packages/GMT/fZQQL/src/psscale.jl:86
 [5] top-level scope at REPL[18]:1
```

-----------


```julia
julia> rb = makecpt(range=(-200,1000,100), cmap=:rainbow)
GMT.GMTcpt([0.791666666666667 0.0 1.0; 0.375 0.0 1.0; … ; 1.0 0.625 0.0; 1.0 0.20833333333333337 0.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [-200.0 -100.0; -100.0 0.0; … ; 800.0 900.0; 900.0 1000.0], [-200.0, 1000.0], [0.0 0.0 0.0; 1.0 1.0 1.0; 0.5 0.5 0.5], 24, NaN, [0.791666666666667 0.0 … 0.0 1.0; 0.375 0.0 … 0.0 1.0; … ; 1.0 0.625 … 0.625 0.0; 1.0 0.20833333333333337 … 0.20833333333333337 0.0], "hsv", String[])

julia> colorbar(pos=(justify=:CT, width=10, offset=(0,2), horizontal=true), cmap=rb, show=1,fmt=:png)
psscale [ERROR]: Option -DJ requires the -R option
ERROR: Something went wrong when calling the module. GMT error number = 71
Stacktrace:
 [1] error(::String, ::Int32) at ./error.jl:42
 [2] gmt(::String, ::GMT.GMTcpt) at /Users/t/.julia/packages/GMT/fZQQL/src/gmt_main.jl:246
 [3] finish_PS_module(::Dict{Symbol,Any}, ::String, ::String, ::Bool, ::Bool, ::Bool, ::GMT.GMTcpt) at /Users/t/.julia/packages/GMT/fZQQL/src/common_options.jl:2701
 [4] colorbar(::String, ::Nothing; first::Bool, kwargs::Base.Iterators.Pairs{Symbol,Any,NTuple{4,Symbol},NamedTuple{(:pos, :cmap, :show, :fmt),Tuple{NamedTuple{(:justify, :width, :offset, :horizontal),Tuple{Symbol,Int64,Tuple{Int64,Int64},Bool}},GMT.GMTcpt,Int64,Symbol}}}) at /Users/t/.julia/packages/GMT/fZQQL/src/psscale.jl:86
 [5] top-level scope at REPL[25]:1
```