### PR TITLE
Make the default of map projection be no-antialias.

### DIFF
--- a/docs/src/grdimage.md
+++ b/docs/src/grdimage.md
@@ -102,9 +102,9 @@ Optional Arguments
 - **N** or **noclip** : -- *noclip=true*\
     Do not clip the image at the map boundary (only relevant for non-rectangular maps).
 
-- **Q** or *nan\_t* or *nan\_alpha* : *nan\_alpha=true*\
-    Make grid nodes with z = NaN transparent, using the color-masking feature in PostScript Level 3
-    (the PS device must support PS Level 3).
+- **Q** or *nan\_alpha* or *alpha\_color*: *nan\_alpha=true* or *alpha\_color=true|(r,g,b)*\
+    Make grid nodes with z = NaN transparent. If input is an image *alpha\_color* picks one color (default is
+    black) and makes it transparent (requires GMT6.2 and above).
 
 - **R** or **region** or **limits** : -- *limits=(xmin, xmax, ymin, ymax)* **|** *limits=(BB=(xmin, xmax, ymin, ymax),)*
    **|** *limits=(LLUR=(xmin, xmax, ymin, ymax),units="unit")* **|** ...more 

--- a/src/gmt_main.jl
+++ b/src/gmt_main.jl
@@ -463,19 +463,18 @@ function get_grid(API::Ptr{Nothing}, object)
 		k = 1
 		for row = ind_y
 			for col = 1:nx
-				ij = GMT_IJP(row, col, mx, padTop, padLeft)		# This one is Int64
-				z[k] = t[ij]
+				z[k] = t[GMT_IJP(row, col, mx, padTop, padLeft)]
 				k = k + 1
 			end
 		end
 		grd_mem_layout[1] = ""			# Reset because this variable is global
 	else
-		for col = 1:nx
-			for row = 1:ny
-				ij = GMT_IJP(row, col, mx, padTop, padLeft)		# This one is Int64
-				z[row,col] = t[ij]
-			end
-		end
+		#for col = 1:nx
+			#for row = 1:ny
+				#z[row,col] = t[GMT_IJP(row, col, mx, padTop, padLeft)]
+			#end
+		#end
+		[z[row,col] = t[GMT_IJP(row, col, mx, padTop, padLeft)] for col = 1:nx, row = 1:ny]
 		grd_mem_layout[1] = ""
 	end
 
@@ -876,7 +875,7 @@ function image_init(API::Ptr{Nothing}, Img::GMTimage, pad::Int=0)
 				end
 			end
 		end
-		CTRL.proj_linear[1] = true		# Use only once and reset back to linear
+		#CTRL.proj_linear[1] = true		# Use only once and reset back to linear
 	else
 		#t = unsafe_wrap(Array, convert(Ptr{UInt8}, Ib.data), length(Img.image))
 		#[t[k] = Img.image[k] for k = 1:length(Img.image)]

--- a/src/grdimage.jl
+++ b/src/grdimage.jl
@@ -40,9 +40,9 @@ Parameters
     Do not clip the image at the map boundary.
     ($(GMTdoc)grdimage.html#n)
 - $(GMT.opt_P)
-- **Q** | **nan_t** | **nan_alpha** :: [Type => Bool]
+- **Q** | **alpha_color** | **nan_alpha** :: [Type => Bool | Tuple | Str]	``Q = true | Q = (r,g,b)``
 
-    Make grid nodes with z = NaN transparent, using the colormasking feature in PostScript Level 3.
+	Make grid nodes with z = NaN transparent, or pick a color for transparency in a image.
 - $(GMT.opt_R)
 - $(GMT.opt_U)
 - $(GMT.opt_V)
@@ -67,7 +67,7 @@ function grdimage(cmd0::String="", arg1=nothing, arg2=nothing, arg3=nothing; fir
 	cmd, opt_B, opt_J, opt_R = parse_BJR(d, "", "", O, " -JX12c/0")
 	cmd, = parse_common_opts(d, cmd, [:UVXY :params :c :f :n :p :t], first)
 	cmd  = parse_these_opts(cmd, d, [[:A :img_out :image_out], [:D :img_in :image_in], [:E :dpi], [:G :bit_color],
-	                                 [:M :monochrome], [:N :noclip], [:Q :nan_t :nan_alpha]])
+	                                 [:M :monochrome], [:N :noclip], [:Q :nan_alpha :alpha_color]])
 	cmd = add_opt(d, cmd, "%", [:layout :mem_layout], nothing)
 
 	cmd, got_fname, arg1 = find_data(d, cmd0, cmd, arg1)		# Find how data was transmitted
@@ -101,6 +101,7 @@ function grdimage(cmd0::String="", arg1=nothing, arg2=nothing, arg3=nothing; fir
 		do_finish = true
 	end
 	(isa(arg1, GMTimage) && GMTver < v"6.2" && !occursin("-A", cmd)) && (arg1 = ind2rgb(arg1))	# Prev to 6.2 indexed imgs lost colors
+	
 	return finish_PS_module(d, cmd, "", K, O, do_finish, arg1, arg2, arg3, arg4)
 end
 

--- a/src/grdproject.jl
+++ b/src/grdproject.jl
@@ -47,8 +47,9 @@ function grdproject(cmd0::String="", arg1=nothing; kwargs...)
 
 	length(kwargs) == 0 && return monolitic("grdproject", cmd0, arg1)
 
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
-	cmd, = parse_common_opts(d, "", [:R :V_params :n :r])
+    d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+    cmd = parse_n(d, "", true)[1]              # Here we keep the GMT default to Antialiasing
+	cmd = parse_common_opts(d, cmd, [:R :V_params :r])[1]
 	if ((val = find_in_dict(d, [:J :proj :projection], false)[1]) !== nothing)  # Here we don't want any default value
 		cmd = parse_J(d, cmd, "", false)[1];
 	end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,7 +63,7 @@ if (got_it)					# Otherwise go straight to end
 	@test GMT.parse_c(Dict(:c => "1"), "")[1] == " -c0"
 	@test GMT.parse_l(Dict(:l => "ai ai"), "")[2] == " -l\"ai ai\""
 	@test GMT.parse_l(Dict(:l => (text="ai ai", vspace=3)), "")[2] == " -l\"ai ai\"+G3"
-	@test GMT.parse_n(Dict(:n => (bicubic=true,antialiasing=true,bc=:g)), "")[2] == " -nc+a+bg"
+	@test GMT.parse_n(Dict(:n => (bicubic=true,antialiasing=true,bc=:g)), "")[2] == " -nc+bg"
 	@test GMT.parse_inc(Dict(:inc => (x=1.5, y=2.6, unit="meter")),"", [:I :inc], "I") == " -I1.5e/2.6e"
 	@test GMT.parse_inc(Dict(:inc => (x=1.5, y=2.6, unit="m")),"", [:I :inc], "I") == " -I1.5m/2.6m"
 	@test GMT.parse_inc(Dict(:inc => (x=1.5, y=2.6, unit="data")),"", [:I :inc], "I") == " -I1.5/2.6u"
@@ -211,7 +211,7 @@ if (got_it)					# Otherwise go straight to end
 	GMT.mat2img(img16, histo_bounds=[8440 13540]);
 	GMT.mat2img(img16, histo_bounds=[8440 13540 800 20000 1000 30000]);
 	GMT.mat2img(rand(UInt16,32,32,3),stretch=:auto);
-	
+
 	D = mat2ds([0 0; 1 1],["a", "b"]);	D.header = "a";
 	GMT.make_zvals_vec(D, ["a", "b"], [1,2]);
 	GMT.edit_segment_headers!([D], [1], "0")
@@ -661,11 +661,11 @@ if (got_it)					# Otherwise go straight to end
 	grdview!(G, J="X6i", JZ=5,  I=45, Q="s", C="topo", R="-15/15/-15/15/-1/1", view="120/30", Vd=dbg2);
 	grdview!(G, G=G, J="X6i", JZ=5,  I=45, Q="s", C="topo", R="-15/15/-15/15/-1/1", view="120/30", Vd=dbg2);
 	r = grdview!(G, plane=(-6,:lightgray), surftype=(surf=true,mesh=:red), view="120/30", Vd=dbg2);
-	@test startswith(r, "grdview  -R -J -p120/30 -N-6+glightgray -Qsmred")
+	@test startswith(r, "grdview  -R -J -n+a -p120/30 -N-6+glightgray -Qsmred")
 	r = grdview(G, surf=(waterfall=(:rows,:red),surf=true, mesh=true, img=50), Vd=dbg2);
-	@test startswith(r, "grdview  -R0/360/-90/90 -JX12c/0 -Baf -Bza -Qmyredsmi50")
-	@test startswith(grdview(G, surf=(waterfall=:rows,), Vd=dbg2), "grdview  -R0/360/-90/90 -JX12c/0 -Baf -Bza -Qmy")
-	@test startswith(grdview(G, surf=(waterfall=(rows=true, fill=:red),), Vd=dbg2), "grdview  -R0/360/-90/90 -JX12c/0 -Baf -Bza -Qmyred")
+	@test startswith(r, "grdview  -R0/360/-90/90 -JX12c/0 -Baf -Bza -n+a -Qmyredsmi50")
+	@test startswith(grdview(G, surf=(waterfall=:rows,), Vd=dbg2), "grdview  -R0/360/-90/90 -JX12c/0 -Baf -Bza -n+a -Qmy")
+	@test startswith(grdview(G, surf=(waterfall=(rows=true, fill=:red),), Vd=dbg2), "grdview  -R0/360/-90/90 -JX12c/0 -Baf -Bza -n+a -Qmyred")
 	@test_throws ErrorException("Wrong way of setting the drape (G) option.")  grdview(rand(16,16), G=(1,2))
 	I = mat2grid(rand(Float32,128,128));
 	grdview(rand(128,128), G=(Gr,Gg,Gb), I=I, J=:X12, JZ=5, Q=:i, view="145/30")
@@ -698,9 +698,9 @@ if (got_it)					# Otherwise go straight to end
 	imshow(-2:0.1:2, -1:0.1:3,"rosenbrock", Vd=dbg2);
 	imshow(-2:0.1:2, "rosenbrock", Vd=dbg2);
 	imshow("lixo", Vd=dbg2);
-	#mat = reshape(UInt8.([255 0 0 0 0 0 0 0 0 0 0 0 0 255 0 0 0 0 0 0 0 0 0 0 0 0 255]), 3,3,3);
-	#I = mat2img(mat, hdr=[0.0 3 0 3 0 255 1 1 1]);
-	#imshow(I, J=:Merc, show=false)
+	mat = reshape(UInt8.([255 0 0 0 0 0 0 0 0 0 0 0 0 255 0 0 0 0 0 0 0 0 0 0 0 0 255]), 3,3,3);
+	I = mat2img(mat, hdr=[0.0 3 0 3 0 255 1 1 1]);
+	imshow(I, J=:Merc, show=false)
 	GMT.mat2grid("ackley");
 	GMT.mat2grid("egg");
 	GMT.mat2grid("sombrero");


### PR DESCRIPTION
Reason. GMT default to antialias is slow (> 70 % increase time) without visible benefits.

grdproject still defaults to antialias.