### PR TITLE
Let image_init() always declare image arrays as externally allocated

### DIFF
--- a/src/GMT.jl
+++ b/src/GMT.jl
@@ -7,11 +7,12 @@ struct CTRLstruct
 	proj_linear::Vector{Bool}		# To know if images sent to GMT need Pad
 	callable::Array{Symbol}			# Modules that can be called inside other modules
 	pocket_call::Vector{Any}		# To temporarilly store data needed by modules sub-calls
+	gmt_mem_bag::Vector{Ptr{Cvoid}}	# To temporarilly store a GMT owned memory to be freed in gmt()
 end
 
 struct CTRLstruct2
-	first::Vector{Bool}				# Signlas that we are sarting a new plot (used to set params)
-	points::Vector{Bool}			# If maps are using points ass coordinates
+	first::Vector{Bool}				# Signal that we are starting a new plot (used to set params)
+	points::Vector{Bool}			# If maps are using points as coordinates
 	fname::Vector{String}			# Store the full name of PS being constructed
 end
 
@@ -46,7 +47,7 @@ const global box_str = [""]
 const def_fig_size  = "14c/9.5c"            # Default fig size for plot like programs. Approx 16/11
 const def_fig_axes  = " -Baf -BWSen"        # Default fig axes for plot like programs
 const def_fig_axes3 = " -Baf -Bza"  		#		"" but for 3D views
-const global CTRL = CTRLstruct(zeros(6), [true], [:clip, :coast, :colorbar, :basemap, :logo, :text, :arrows, :lines, :scatter, :scatter3, :plot, :plot3, :hlines, :vlines], [nothing])
+const global CTRL = CTRLstruct(zeros(6), [true], [:clip, :coast, :colorbar, :basemap, :logo, :text, :arrows, :lines, :scatter, :scatter3, :plot, :plot3, :hlines, :vlines], [nothing], [C_NULL])
 const global CTRLshapes = CTRLstruct2([true], [true], [""])
 
 if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@optlevel"))

--- a/src/common_options.jl
+++ b/src/common_options.jl
@@ -527,7 +527,7 @@ function guess_proj(lonlim, latlim)
 		parallels = latlim .+ diff(latlim) .* [1/6 -1/6]
 		proj = string(" -JD", sum(lonlim)/2, '/', sum(latlim)/2, '/', parallels[1], '/', parallels[2])	# eqdc
 	elseif abs(latlim[2]-latlim[1]) < 85 && maximum(abs.(latlim)) < 90	# doesn't extend to the pole, not straddling equator
-		proj = string(" -JI", '/', sum(lonlim)/2)						# Sinusoidal
+		proj = string(" -JI", sum(lonlim)/2)							# Sinusoidal
 	elseif (maximum(latlim) == 90 && minimum(latlim) >= 75)
 		proj = string(" -JS", sum(lonlim)/2, "/90")						# General Stereographic - North Pole
 	elseif (minimum(latlim) == -90 && maximum(latlim) <= -75)

--- a/src/libgmt.jl
+++ b/src/libgmt.jl
@@ -454,6 +454,11 @@ function gmt_get_rgb_from_z(API::Ptr{Cvoid}, P::Ptr{GMT.GMT_PALETTE}, value::Cdo
 	ccall((:gmt_get_rgb_from_z, thelib), Cint, (Cstring, Ptr{Cvoid}, Cdouble, Ptr{Cdouble}), GMT_, P, value, rgb)
 end
 
+function gmt_free_mem(API::Ptr{Cvoid}, mem)
+	GMT_ = GMT_Get_Ctrl(API)
+	ccall((:gmt_free_func, thelib), Cvoid, (Cstring, Ptr{Cvoid}, Bool, Cstring), GMT_, mem, true, "Julia")
+end
+
 function sprintf(format::String, x...)
 	strp = Ref{Ptr{Cchar}}(0)
 	if (length(x) == 1)

--- a/test/test_common_opts.jl
+++ b/test/test_common_opts.jl
@@ -258,6 +258,8 @@
 	GMT.guess_proj([0., 20.], [80.0, 90.])
 	GMT.guess_proj([0., 20.], [-90.0, -80.])
 	GMT.guess_proj([0., 20.], [-6.0, 90.])
+	GMT.guess_proj([0., 20.], [-30.0, 30.])
+	GMT.guess_proj([0., 20.], [-40.0, 60.])
 	GMT.guess_WESN(Dict(:p=>(350,2)), "")
 	GMT.guess_WESN(Dict(:p=>"350/2"), "")
 	GMT.parse_q(Dict(:p=>(350,2)), "")


### PR DESCRIPTION
Due to the pad horror the only way I found was to declare all image arrays external, even when GMT allocated memory is used. For those cases, store the GMT memory pointer and free in gmt().