### PR TITLE
Strengthen the interface between GMTimages and GDAL datasets

### DIFF
--- a/src/common_options.jl
+++ b/src/common_options.jl
@@ -1797,8 +1797,6 @@ function get_cpt_set_R(d::Dict, cmd0::String, cmd::String, opt_R::String, got_fn
 		elseif (find_in_dict(d, [:C :color :cmap], false)[1] !== nothing)
 			@warn("You are possibly asking to assign a CPT to an image. That is not allowed by GMT. See function image_cpt!")
 		end
-	#elseif (prog == "grdimage" && !isa(arg1, GMTimage) && (arg3 === nothing && !occursin("-D", cmd)))
-		#get_cpt = true		# This still lieve out the case when the r,g,b were sent as a text.
 	elseif (prog == "grdcontour" || prog == "pscontour")	# Here C means Contours but we cheat, so always check if C, color, ... is present
 		get_cpt = true;		cpt_opt_T = ""		# This is hell. And what if I want to auto generate a cpt?
 		if (prog == "grdcontour" && !occursin("+c", cmd))  in_bag = false  end

--- a/src/gdal_tools.jl
+++ b/src/gdal_tools.jl
@@ -170,6 +170,8 @@ function get_gdaldataset(indata)
 	else
 		ds = indata		# If it's not a GDAL dataset or convenient descendent, shit will follow soon
 	end
+	(ds === nothing) && error("Error fetching the GDAL dataset from input $(typeof(indata))")
+	return ds
 end
 
 # ---------------------------------------------------------------------------------------------------
@@ -182,10 +184,12 @@ Convert a 24bit RGB image to 8bit paletted.
 - Use 'gdataset=true' to return a GDAL dataset. The default is to return a GMTimage object.
 - Select the number of colors in the generated color table. Defaults to 256.
 """
-function dither(indata, opts=String[]; n_colors::Integer=8, save::String="", gdataset::Bool=false)
+function dither(indata, opts=String[]; n_colors::Integer=256, save::String="", gdataset::Bool=false)
 	# ...
 	src_ds = get_gdaldataset(indata)
 	(nraster(src_ds) < 3) && error("Input image must have at least 3 bands")
+	(isa(indata, GMT.GMTimage) && !startswith(indata.layout, "TRB")) &&
+		error("Image memory layout must be `TRB` and not $(indata.layout). Load image with gdaltranslate()")
 	r_band, g_band, b_band = getband(src_ds, 1), getband(src_ds, 2), getband(src_ds, 3)
 
 	drv_name = (save == "") ? "MEM" : "GTiff"

--- a/src/grdimage.jl
+++ b/src/grdimage.jl
@@ -105,7 +105,7 @@ function grdimage(cmd0::String="", arg1=nothing, arg2=nothing, arg3=nothing; fir
 	(isa(arg1, GMTimage) && GMTver <= v"6.1.1" && !occursin("-A", _cmd[1])) && (arg1 = ind2rgb(arg1))	# Prev to 6.2 indexed imgs lost colors
 
 	_cmd, K = finish_PS_nested(d, _cmd, K)
-	return finish_PS_module(d, _cmd, "", K, O, do_finish, arg1, arg2, arg3, arg4)
+	finish_PS_module(d, _cmd, "", K, O, do_finish, arg1, arg2, arg3, arg4)
 end
 
 # ---------------------------------------------------------------------------------------------------

--- a/src/utils_types.jl
+++ b/src/utils_types.jl
@@ -373,18 +373,24 @@ end
 
 # ---------------------------------------------------------------------------------------------------
 """
-    image_cpt!(img::GMTimage, cpt::GMTcpt, clear::Bool=false)
+    image_cpt!(img::GMTimage, cpt::GMTcpt, clear=false)
+or
+    image_cpt!(img::GMTimage, cpt::String, clear=false)
 
 Add (or replace) a colormap to a GMTimage object from the colors in the cpt.
 This should have effect only if IMG is indexed.
 Use `image_cpt!(img, clear=true)` to remove a previously existent `colormap` field in IMG
 """
+function image_cpt!(img::GMTimage, cpt::String)
+	C = gmtread(cpt)
+	image_cpt!(img, C)
+end
 function image_cpt!(img::GMTimage, cpt::GMTcpt)
 	# Insert the cpt info in the img.colormap member
 	n = 1
 	colormap = fill(Int32(255), size(cpt.colormap,1) * 4)
 	for k = 1:size(cpt.colormap,1)
-		colormap[n:n+2] = round.(Int32, cpt.colormap[k,:] .* 255);	n += 3
+		colormap[n:n+2] = round.(Int32, cpt.colormap[k,:] .* 255);	n += 4
 	end
 	img.colormap = colormap
 	img.n_colors = size(cpt.colormap,1)

--- a/test/test_gdal.jl
+++ b/test/test_gdal.jl
@@ -135,6 +135,12 @@ Gdal.GDALDestroyDriverManager()
 	Gdal.metadata(ds_src)
 	Gdal.GDALGetDescription(ds_src.ptr)
 
+	rb = Gdal.getband(ds_src, 1)
+	@test Gdal.getnodatavalue(rb) === nothing
+	Gdal.setnodatavalue!(rb, -100)
+	@test Gdal.getnodatavalue(rb) ≈ -100
+	Gdal.getcolorinterp(rb)
+
 	line = Gdal.createlinestring()
 	Gdal.addpoint!(line, 1116651.439379124,  637392.6969887456)
 	Gdal.OGR_G_SetPoints(line.ptr, 3, [1.,2,3], sizeof(Float64), [4.,5,6], sizeof(Float64), [7.,8,9], sizeof(Float64))


### PR DESCRIPTION
Introduce the ressurectgdal() function to minimize the effect of GMT calls to GDALDestroyDriverManager()