### PR TITLE
Fix modernmode white margins cropring

### DIFF
--- a/src/common_docs.jl
+++ b/src/common_docs.jl
@@ -8,7 +8,7 @@ const opt_C = "**C** | **color** | **cmap** :: [Type => Str]		``Arg = [cpt |mast
 
 const opt_J = "**J** | **proj** | **projection** :: [Type => String]
 
-    Select map projection. Defaults to 12x8 cm with linear (non-projected) maps.
+    Select map projection. Defaults to 14x9.5 cm with linear (non-projected) maps.
     (http://docs.generic-mapping-tools.org/latest/gmt.html#j-full)"
 
 const opt_Jz = "**Jz** | **zscale** | **zsize** :: [Type => String]"

--- a/src/common_options.jl
+++ b/src/common_options.jl
@@ -3019,8 +3019,8 @@ function finish_PS_module(d::Dict, cmd::Vector{String}, opt_extra::String, K::Bo
 	img_mem_layout[1] = add_opt(d, "", "", [:layout])
 	if (img_mem_layout[1] == "images")  img_mem_layout[1] = "I   "  end	# Special layout for Images.jl
 
-	if (fname_ext != "ps")				# Exptend to a larger paper size (5 x A0)
-		cmd[1] *= " --PS_MEDIA=11920x16850"
+	if (fname_ext != "ps" && !IamModern[1])				# Exptend to a larger paper size (5 x A0)
+		cmd[1] *= " --PS_MEDIA=11920x16850"				# In Modern mode GMT takes care of this.
 	end
 
 	for k = 1:length(cmd)

--- a/src/proj_utils.jl
+++ b/src/proj_utils.jl
@@ -335,12 +335,12 @@ orthodrome(ds::Gdal.AbstractDataset; step=0, unit=:m, np=0, proj::String="", eps
 function orthodrome(D::Vector{<:GMTdataset}; step=0, unit=:m, np=0, proj::String="", epsg::Integer=0)
 	_D = Vector{GMTdataset}(undef, length(D))
 	for k = 1:length(D)
-		_D[k] = mat2ds(orthodrome(D[k].data; step=step, unit=unit, np=np, proj = (proj == "") ? D[k].proj4 : proj, epsg=epsg), D[k])
+		_D[k] = mat2ds(orthodrome(D[k].data; step=step, unit=unit, np=np, proj = (proj == "") ? D[k].proj4 : proj, epsg=epsg))[1]
 	end
 	return (length(_D) == 1) ? _D[1] : _D		# Drop the damn Vector singletons
 end
 function orthodrome(D::GMTdataset; step=0, unit=:m, np=0, proj::String="", epsg::Integer=0)
-	mat2ds(orthodrome(D.data; step=step, unit=unit, np=np, proj = (proj == "") ? D.proj4 : proj, epsg=epsg), D)
+	mat2ds(orthodrome(D.data; step=step, unit=unit, np=np, proj = (proj == "") ? D.proj4 : proj, epsg=epsg))[1]
 end
 
 function orthodrome(line::Matrix{<:Real}; step=0, unit=:m, np=0, proj::String="", epsg::Integer=0)

--- a/src/surface.jl
+++ b/src/surface.jl
@@ -42,6 +42,10 @@ Parameters
 - **Lu** | **upper** :: [Type => Str | Number]
 
     ($(GMTdoc)surface.html#l)
+- **M** | **mask** :: [Type => Number]      `Arg = max_radius`
+
+    After solving for the surface, apply a mask so that nodes farther than max_radius away from a data constraint is set to NaN.
+    ($(GMTdoc)surface.html#m)
 - **N** | **max_iter** :: [Type => Number]
 
     Number of iterations. Iteration will cease when convergence_limit is reached or when number of
@@ -83,7 +87,7 @@ function surface(cmd0::String="", arg1=nothing; kwargs...)
 	
 	cmd, = parse_common_opts(d, "", [:R :I :V_params :a :bi :di :e :f :h :i :r :yx])
 	cmd  = parse_these_opts(cmd, d, [[:A :aspect_ratio], [:C :convergence], [:G :grid :outgrid], 
-	                                 [:Ll :lower], [:Lu :upper], [:N :max_iter], [:Q :suggest], [:S :search_radius], [:T :tension], [:Z :over_relaxation]])
+	                                 [:Ll :lower], [:Lu :upper], [:M :mask], [:N :max_iter], [:Q :suggest], [:S :search_radius], [:T :tension], [:Z :over_relaxation]])
 	cmd, args, n, = add_opt(d, cmd, 'D', [:D :breakline], :data, Array{Any,1}([arg1, arg2]), (zlevel="+z",))
 	if (n > 0)  arg1, arg2 = args[:]  end
 

--- a/test/test_proj4.jl
+++ b/test/test_proj4.jl
@@ -23,5 +23,6 @@
 	wkt2proj(wkt)
 	loxo = loxodrome_direct(0,0,45, 10000)
 	loxo = loxodrome([0 0; 30 50], step=100, unit=:k);
+	orto = orthodrome(mat2ds([0 0; 30 50]), step=100, unit=:k);
 	dist, azim = GMT.loxodrome_inverse(0,0,5,5)
 end


### PR DESCRIPTION
In modern mode and after the default img format changing in 0.32 images were not white cropped.