### PR TITLE
Try to minimize effects of a nasty bug introduced in GMT6.2.0

### DIFF
--- a/src/common_options.jl
+++ b/src/common_options.jl
@@ -3039,7 +3039,7 @@ function showfig(d::Dict, fname_ps::String, fname_ext::String, opt_T::String, K:
 			elseif (Sys.islinux() || Sys.isbsd()) run(`xdg-open $(out)`)
 			end
 		end
-		(ThemeIsOn[1]) && (reset_defaults(API);	ThemeIsOn[1] = false)
+		(ThemeIsOn[1]) && (pure_modern();	ThemeIsOn[1] = false)
 	end
 	return nothing
 end

--- a/src/gmt_main.jl
+++ b/src/gmt_main.jl
@@ -175,7 +175,8 @@ function gmt(cmd::String, args...)
 	pad = 2
 	if (!isa(API, Ptr{Nothing}) || API == C_NULL)
 		API = GMT_Create_Session("GMT", pad, GMT_SESSION_NOEXIT + GMT_SESSION_EXTERNAL + GMT_SESSION_COLMAJOR)
-		if (API == C_NULL)  error("Failure to create a GMT Session")  end
+		(API == C_NULL) && error("Failure to create a GMT Session")
+		#pure_modern()			# Set the MODERN theme
 	end
 
 	if (g_module == "destroy")

--- a/src/psxy.jl
+++ b/src/psxy.jl
@@ -201,6 +201,14 @@ function common_plot_xyz(cmd0::String, arg1, caller::String, first::Bool, is3D::
 	arg1 = helper_multi_cols(d, arg1, mcc, opt_R, opt_S, opt_W, caller, is3D, multi_col, _cmd,
 	                         sub_module, g_bar_fill, got_Ebars, got_usr_R)
 
+	# Try to limit the damage of this Fker bug in 6.2.0
+	if (mcc || got_Ebars && (GMTver == v"6.2.0" && isGMTdataset(arg1) && occursin(" -i", cmd)) )
+		if (isa(arg1, GMTdataset))	arg1 = arg1.data
+		elseif (isa(arg1, Vector{<:GMTdataset}))
+			(length(arg1) > 1) && @warn("Due to a bug in GMT6.2.0 I'm forced to use only the first segment")
+			arg1 = arg1[1].data
+		end
+	end
 	(!IamModern[1]) && put_in_legend_bag(d, _cmd, arg1)
 
 	_cmd = gmt_proggy .* _cmd				# In any case we need this
@@ -406,7 +414,7 @@ function make_color_column(d::Dict, cmd::String, opt_i::String, len::Int, N_args
 	if (!(N_args > n_prev || len < length(cmd)) && mz === nothing)	# No color request, so return right away
 		return cmd, arg1, arg2, N_args, false
 	end
-		
+
 	# Filled polygons with -Z don't need extra col
 	((val = find_in_dict(d, [:G :fill], false)[1]) == "+z") && return cmd, arg1, arg2, N_args, false
 

--- a/src/themes.jl
+++ b/src/themes.jl
@@ -57,7 +57,7 @@ function fonts_colors_settings(fonts, colors, bg_color)
 	gmtlib_setparameter(API, "FONT_TAG", "auto,$(fonts[1]),$(colors[1])")
 	gmtlib_setparameter(API, "FONT_TITLE", "auto,$(fonts[2]),$(colors[1])")
 	gmtlib_setparameter(API, "MAP_DEFAULT_PEN", "0.25p,$(colors[1])")
-	gmtlib_setparameter(API, "MAP_FRAME_PEN", "0.5p,$(colors[1])")
+	gmtlib_setparameter(API, "MAP_FRAME_PEN", "0.75,$(colors[1])")
 	gmtlib_setparameter(API, "MAP_GRID_PEN_PRIMARY", "auto,$(colors[1])")
 	gmtlib_setparameter(API, "MAP_GRID_PEN_SECONDARY", "auto,$(colors[2])")
 	gmtlib_setparameter(API, "MAP_TICK_PEN_PRIMARY", "auto,$(colors[1])")
@@ -68,10 +68,10 @@ end
 # ---------------------------------------------------------------------------------------------------
 function pure_modern()
 	# Set the MODERN mode settings
-	IamModern[1] && return nothing		# Already modern so nothing to do
+	#IamModern[1] && return nothing		# Already modern so nothing to do
 	swapmode(classic=false)				# Set GMT->current.setting.run_mode = GMT_MODERN
 	reset_defaults(API)					# Set the modern mode settings
-	gmtlib_setparameter(API, "MAP_FRAME_PEN", "0.5p")
+	gmtlib_setparameter(API, "MAP_FRAME_PEN", "0.75")
 	swapmode(classic=true)				# Reset GMT->current.setting.run_mode = GMT_CLASSIC
 end
 

--- a/test/test_avatars.jl
+++ b/test/test_avatars.jl
@@ -151,6 +151,7 @@
 	bar(1:5, [20 25; 35 32; 30 34; 35 20; 27 25], fill=["lightblue", "brown"], xticks=(:G1, :G2, :G3, :G4), zticks=(:Z1,:Z2), Vd=dbg2)
 	bar(1:3,[-5 -15 20; 17 10 21; 10 5 15], stacked=1, Vd=dbg2)
 	bar([0. 1 2 3; 1 2 3 4], fill=("red", "green", "blue"), Vd=dbg2)
+	bar(rand(15), color=:rainbow, Y=3)
 	T = mat2ds([1.0 0.446143; 2.0 0.581746; 3.0 0.268978], text=[" "; " "; " "]);
 	bar(T, color=:rainbow, figsize=(14,8), title="Colored bars", Vd=dbg2)
 	T = mat2ds([1.0 0.446143 0; 2.0 0.581746 0; 3.0 0.268978 0], text=[" "; " "; " "]);


### PR DESCRIPTION
When using GMTdatasets and **-i** to access repeated columns GMT Kabooom