### PR TITLE
Fix missing error code

### DIFF
--- a/src/gmt_main.jl
+++ b/src/gmt_main.jl
@@ -280,7 +280,7 @@ function gmt(cmd::String, args...)
 	status = GMT_Call_Module(API, g_module, GMT_MODULE_OPT, LL)
 	if (status != 0)
 		((status < 0) || status == GMT_SYNOPSIS || status == Int('?')) && return
-		error("Something went wrong when calling the module. GMT error number =")
+		error("Something went wrong when calling the module. GMT error number = $status")
 	end
 
 	# 7. Hook up module GMT outputs to Julia array


### PR DESCRIPTION
The gmt function should print the error code when the API call fails.
However, the error code was deleted in the following commit:
https://github.com/GenericMappingTools/GMT.jl/commit/a8905125a0e578f87f8dbb9f192b86e423ba2135#diff-f757a5fd59739f474cf66fd576eab2d7099ebc0bd28dda3ad57e92bfa6ca7829L267
This will put the error code back into the string.