### PR TITLE
Add a metadata field to GMTimage holding a string vector.

### DIFF
--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -39,6 +39,7 @@ Image type
        registration::Int          # Registration type: 0 -> Grid registration; 1 -> Pixel registration
        nodata::Float64            # The value of nodata
        color_interp::String       # If equal to "Gray" an indexed image with no cmap will get a gray cmap
+       metadata::Vector{String}   # To store any metadata that can eventually be passed to GDAL (Optional)
        names::Vector{String}      # To use whith multi-band and when bands have names (Optional)
        x::Array{Float64,1}        # [1 x n_columns] vector with XX coordinates
        y::Array{Float64,1}        # [1 x n_rows]    vector with YY coordinates

--- a/src/gmt_main.jl
+++ b/src/gmt_main.jl
@@ -47,6 +47,7 @@ mutable struct GMTimage{T<:Unsigned, N} <: AbstractArray{T,N}
 	registration::Int
 	nodata::Float64
 	color_interp::String
+	metadata::Vector{String}
 	names::Vector{String}
 	x::Array{Float64,1}
 	y::Array{Float64,1}
@@ -65,7 +66,7 @@ Base.setindex!(I::GMTimage{T,N}, val, inds::Vararg{Int,N}) where {T,N} = I.image
 Base.BroadcastStyle(::Type{<:GMTimage}) = Broadcast.ArrayStyle{GMTimage}()
 function Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{GMTimage}}, ::Type{ElType}) where ElType
 	I = find4similar(bc.args)		# Scan the inputs for the GMTimage:
-	GMTimage(I.proj4, I.wkt, I.epsg, I.range, I.inc, I.registration, I.nodata, I.color_interp, I.names, I.x, I.y, I.v, similar(Array{ElType}, axes(bc)), I.colormap, I.n_colors, I.alpha, I.layout, I.pad)
+	GMTimage(I.proj4, I.wkt, I.epsg, I.range, I.inc, I.registration, I.nodata, I.color_interp, I.metadata, I.names, I.x, I.y, I.v, similar(Array{ElType}, axes(bc)), I.colormap, I.n_colors, I.alpha, I.layout, I.pad)
 end
 find4similar(I::GMTimage, rest) = I
 
@@ -598,7 +599,7 @@ function get_image(API::Ptr{Nothing}, object)::GMTimage
 
 	# Return image via a uint8 matrix in a struct
 	cinterp = (I.color_interp != C_NULL) ? unsafe_string(I.color_interp) : ""
-	out = GMTimage("", "", 0, zeros(6)*NaN, zeros(2)*NaN, 0, NaN, cinterp, String[], X, Y,
+	out = GMTimage("", "", 0, zeros(6)*NaN, zeros(2)*NaN, 0, NaN, cinterp, String[], String[], X, Y,
 	               zeros(nz), t, colormap, n_colors, Array{UInt8,2}(undef,1,1), layout, 0)
 
 	GMT_Set_AllocMode(API, GMT_IS_IMAGE, object)

--- a/test/test_common_opts.jl
+++ b/test/test_common_opts.jl
@@ -207,7 +207,7 @@
 	img16 = rand(UInt16, 16, 16, 3);
 	I = GMT.mat2img(img16);
 	img16 = rand(UInt16, 4, 4, 3);
-	I = GMT.GMTimage("", "", 0, [1.,4,1,4,0,255], [1., 1], 1, NaN, "", String[], collect(1.:4),collect(1.:4),zeros(3),img16, vec(zeros(Clong,1,3)), 0, Array{UInt8,2}(undef,1,1), "TCBa", 0)
+	I = GMT.GMTimage("", "", 0, [1.,4,1,4,0,255], [1., 1], 1, NaN, "", String[], String[], collect(1.:4),collect(1.:4),zeros(3),img16, vec(zeros(Clong,1,3)), 0, Array{UInt8,2}(undef,1,1), "TCBa", 0)
 	GMT.mat2img(I);
 	GMT.mat2img(img16, histo_bounds=8440);
 	GMT.mat2img(img16, histo_bounds=[8440 13540]);

--- a/test/test_views.jl
+++ b/test/test_views.jl
@@ -69,7 +69,7 @@ imshow("lixo", Vd=dbg2);
 mat = reshape(UInt8.([255 0 0 0 0 0 0 0 0 0 0 0 0 255 0 0 0 0 0 0 0 0 0 0 0 0 255]), 3,3,3);
 I = mat2img(mat, hdr=[0.0 3 0 3 0 255 1 1 1]);
 imshow(I, J=:Merc, show=false)
-I = GMT.GMTimage("", "", 0, [1., 10, 1, 10, 0, 1, 1, 1, 1], [1., 1], 1, NaN, "gray", String[], collect(1.:11), collect(1.:11), [0.],rand(UInt16,10,10), zeros(Clong,3), 0, Array{UInt8,2}(undef,1,1), "TRBa", 0);
+I = GMT.GMTimage("", "", 0, [1., 10, 1, 10, 0, 1, 1, 1, 1], [1., 1], 1, NaN, "gray", String[], String[], collect(1.:11), collect(1.:11), [0.],rand(UInt16,10,10), zeros(Clong,3), 0, Array{UInt8,2}(undef,1,1), "TRBa", 0);
 imshow(I,Vd=dbg2)
 imshow(mat2ds([0 0; 10 0; 10 10; 11 10]), Vd=2)
 GMT.mat2grid("ackley");


### PR DESCRIPTION
Can be useful for example to pass metadata to GDAL.