### PR TITLE
ci: Add test gmt command that starts a GMT session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
           set -x -e
           gmt --version
           gmt --help
+          gmt begin testmap; gmt basemap -R0/9/0/5 -Jx1 -Bf1a2 -Bx+lDistance -By+l"No of samples" -BWeS; gmt end
         if: matrix.run_in_pr == true || github.event_name != 'pull_request'
 
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fail the CI early if we can't start a GMT session.

I suspect this could be the case for current failures on Ubuntu, I can't reproduce the failures on my Linux machines.

If this fails with static TLS errors, then we need to modify the Linux build flags, maybe `-flts-model=local-dynamic` as [suggested here](https://github.com/microsoft/mimalloc/issues/147).