### PR TITLE
use VersionParsing to parse non-semver versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ VersionParsing = "81def892-9a0e-5fdd-b105-ffc91e053289"
 [compat]
 julia = "1.5"
 Conda = "1.0"
+VersionParsing = "1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Dates  = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+VersionParsing = "81def892-9a0e-5fdd-b105-ffc91e053289"
 
 [compat]
 julia = "1.5"

--- a/src/GMT.jl
+++ b/src/GMT.jl
@@ -26,7 +26,7 @@ function get_GMTver()
 	try						# First try to find an existing GMT installation (RECOMENDED WAY)
 		(get(ENV, "FORCE_INSTALL_GMT", "") != "") && error("Forcing an automatic GMT install")
 		ver = readlines(`gmt --version`)[1]
-		out = ((ind = findfirst('_', ver)) === nothing) ? VersionNumber(ver) : VersionNumber(ver[1:ind-1])
+		out = VersionParsing.vparse(ver)
 		return out, false, "", "", "", ""
 	catch err1;		println(err1)		# If not, install GMT
 		ENV["INSTALL_GMT"] = "1"
@@ -40,8 +40,8 @@ function get_GMTver()
 			else
 				Pkg.build("GMT");		include(depfile)
 			end
-			ver = readlines(`$(joinpath("$(_GMT_bindir)", "gmt")) --version`)[1]
-			out = ((ind = findfirst('_', ver)) === nothing) ? VersionNumber(ver) : VersionNumber(ver[1:ind-1])
+			ver = first(eachline(`$(joinpath("$(_GMT_bindir)", "gmt")) --version`))
+			out = VersionParsing.vparse(ver)
 			return out, true, _libgmt, _libgdal, _libproj, _GMT_bindir
 		catch err2;		println(err2)
 			return out, false, "", "", "", ""
@@ -75,7 +75,7 @@ const global grd_mem_layout = [""]			# "BRP" is the default for GMT PS images.
 const global current_view   = [""]			# To store the current viewpoint (-p)
 const global multi_col   = Vector{Bool}(undef, 1);multi_col[1] = false	# To allow plottig multiple columns at once (init to false)
 const global IamModern   = Vector{Bool}(undef, 1);IamModern[1] = false		# To know if we are in modern mode
-const global FirstModern = Vector{Bool}(undef, 1);FirstModern[1] = false	# To know 
+const global FirstModern = Vector{Bool}(undef, 1);FirstModern[1] = false	# To know
 const global IamSubplot  = Vector{Bool}(undef, 1);IamSubplot[1]  = false	# To know if we are in subplot mode
 const global usedConfPar = Vector{Bool}(undef, 1);usedConfPar[1] = false	# Hacky solution for the session's memory trouble
 const global ThemeIsOn   = Vector{Bool}(undef, 1);ThemeIsOn[1] = false		# To know if we have an active plot theme


### PR DESCRIPTION
You might want to use the VersionParsing package to parse non-semver versions from external code. 

e.g. I notice that you were manually stopping at underscores, which `vparse` should handle; do you have an example of a version string with an underscore that GMT would return?