### PR TITLE
Catch Vector{GMTdataset} with only one element at birth and make them a GMTdataset

### DIFF
--- a/src/GMT.jl
+++ b/src/GMT.jl
@@ -142,7 +142,7 @@ export
 	buffergeo, circgeo, epsg2proj, epsg2wkt, geod, invgeod, loxodrome, loxodrome_direct, loxodrome_inverse,
 	orthodrome, proj2wkt, wkt2proj,
 
-	colorzones!, rasterzones!, crop, doy2date, date2doy, yeardecimal, median, mean, std, nanmean, nanstd,
+	colorzones, rasterzones!, crop, doy2date, date2doy, yeardecimal, median, mean, std, nanmean, nanstd,
 
 	append2fig, regiongeog, wmsinfo, wmstest, wmsread, polygonlevels
 

--- a/src/contourf.jl
+++ b/src/contourf.jl
@@ -140,7 +140,7 @@ function contourf(cmd0::String="", arg1=nothing, arg2=nothing; first=true, kwarg
 		if (CPT === nothing && CPT_arg === nothing)
 			if (cmd0 != "")
 				info = grdinfo(cmd0 * " -C")
-				C_inc, min, max = gen_contour_vals(info[1].data[5:6], C_int)
+				C_inc, min, max = gen_contour_vals(info.data[5:6], C_int)
 			else
 				C_inc, min, max = gen_contour_vals(arg1, C_int)
 			end
@@ -192,7 +192,7 @@ function contourf(cmd0::String="", arg1=nothing, arg2=nothing; first=true, kwarg
 			d[:C] = CPT;
 		else
 			D = gmtinfo(arg1, C=1)
-			C_inc, min, max = gen_contour_vals(D[1].data[5:6], C_int)
+			C_inc, min, max = gen_contour_vals(D.data[5:6], C_int)
 			d[:C] = makecpt(T=(min, max, C_inc))
 		end
 		d[:I] = true

--- a/src/gdal.jl
+++ b/src/gdal.jl
@@ -1623,7 +1623,8 @@ end
 	gdalvectortranslate(ds::GMT.GMTdataset, opts::Vector{String}=String[]; dest="/vsimem/tmp", gdataset=false, save="") = 				gdalvectortranslate([ds], opts; dest=dest, gdataset=gdataset, save=save)
 	function gdalvectortranslate(ds::Vector{GMT.GMTdataset}, opts::Vector{String}=String[]; dest="/vsimem/tmp", gdataset=false, save="")
 		o = gdalvectortranslate(GMT.gmt2gd(ds), opts; dest=dest, gdataset=gdataset, save=save)
-		(!isa(o, Vector{GMT.GMTdataset}) && dest == "/vsimem/tmp") && deletedatasource(o, "/vsimem/tmp")	# WTF do I need to do this?
+		#(!isa(o, Vector{GMT.GMTdataset}) && dest == "/vsimem/tmp") && deletedatasource(o, "/vsimem/tmp")	# WTF do I need to do this?
+		(!isa(o, GMT.GDtype) && dest == "/vsimem/tmp") && deletedatasource(o, "/vsimem/tmp")	# WTF do I need to do this?
 		o
 	end
 

--- a/src/gdal_tools.jl
+++ b/src/gdal_tools.jl
@@ -71,7 +71,7 @@ function gdaldem(indata, method::String, opts::Vector{String}=String[]; dest="/v
 		append!(opts, ["-compute_edges", "-b", band])
 		if ((val = GMT.find_in_dict(d, [:scale])[1]) === nothing)
 			if (isa(indata, GMT.GMTgrid) && (occursin("longlat", indata.proj4) || occursin("latlong", indata.proj4)) ||
-											grdinfo(indata, C="n")[1].data[end] == 1)
+											grdinfo(indata, C="n").data[end] == 1)
 				append!(opts, ["-s", "111120"])
 			end
 		else

--- a/src/gdal_utils.jl
+++ b/src/gdal_utils.jl
@@ -10,7 +10,7 @@ When DATASET is a string it may contain the file name or the name of a subdatase
 you can use the kwarg `sds` to selec the subdataset numerically. Alternatively, provide the full `sds` name.
 For files with `sds` with a scale_factor (e.g. MODIS data), that scale is applyied automaticaly.
 
-    Examples:
+### Examples:
        G = gd2gmt("AQUA_MODIS.20210228.L3m.DAY.NSST.sst.4km.NRT.nc", sds=1);
     or
        G = gd2gmt("SUBDATASET_1_NAME=NETCDF:AQUA_MODIS.20210228.L3m.DAY.NSST.sst.4km.NRT.nc:sst");
@@ -159,7 +159,6 @@ function gd2gmt_helper(input, sds)
 end
 
 # ---------------------------------------------------------------------------------------------------
-#function gd2gmt(geom::Gdal.AbstractGeometry, proj::String="")::Vector{<:GMTdataset}
 function gd2gmt(geom::Gdal.AbstractGeometry, proj::String="")::Union{GMTdataset, Vector{<:GMTdataset}}
 	# Convert a geometry into a single GMTdataset
 	gmtype = Gdal.getgeomtype(geom)

--- a/src/gmt_main.jl
+++ b/src/gmt_main.jl
@@ -708,7 +708,6 @@ function get_PS(API::Ptr{Nothing}, object::Ptr{Nothing})::GMTps
 end
 
 # ---------------------------------------------------------------------------------------------------
-#function get_dataset(API::Ptr{Nothing}, object::Ptr{Nothing})::Vector{GMTdataset}
 function get_dataset(API::Ptr{Nothing}, object::Ptr{Nothing})::GDtype
 # Given a GMT DATASET D, build an array of segment structure and assign values.
 # Each segment will have 6 items:

--- a/src/gmt_main.jl
+++ b/src/gmt_main.jl
@@ -708,7 +708,8 @@ function get_PS(API::Ptr{Nothing}, object::Ptr{Nothing})::GMTps
 end
 
 # ---------------------------------------------------------------------------------------------------
-function get_dataset(API::Ptr{Nothing}, object::Ptr{Nothing})::Vector{GMTdataset}
+#function get_dataset(API::Ptr{Nothing}, object::Ptr{Nothing})::Vector{GMTdataset}
+function get_dataset(API::Ptr{Nothing}, object::Ptr{Nothing})::GDtype
 # Given a GMT DATASET D, build an array of segment structure and assign values.
 # Each segment will have 6 items:
 # header:	Text string with the segment header (could be empty)
@@ -718,7 +719,7 @@ function get_dataset(API::Ptr{Nothing}, object::Ptr{Nothing})::Vector{GMTdataset
 # proj4:	String with any proj4 information
 # wkt:		String with any WKT information
 
-	(object == C_NULL) && return [GMTdataset()]		# No output produced - return a null data set
+	(object == C_NULL) && return GMTdataset()		# No output produced - return a null data set
 	D::GMT_DATASET = unsafe_load(convert(Ptr{GMT_DATASET}, object))
 
 	seg_out = 0;
@@ -783,7 +784,7 @@ function get_dataset(API::Ptr{Nothing}, object::Ptr{Nothing})::Vector{GMTdataset
 	end
 	set_dsBB!(Darr, false)				# Compute and set the global BoundingBox for this dataset
 
-	return Darr
+	return (length(Darr) == 1) ? Darr[1] : Darr
 end
 
 # ---------------------------------------------------------------------------------------------------

--- a/src/grd_operations.jl
+++ b/src/grd_operations.jl
@@ -99,7 +99,7 @@ function grd_min_max!(G::GMTgrid)
 		tic()
 		t = G.layout;	G.layout = "TRBa"
 		info = grdinfo(G, C=:n, L=0, Vd=1)
-		G.range[5:6] = info[1][5:6]
+		G.range[5:6] = info[5:6]
 		G.layout = t
 		toc()
 	end

--- a/src/grdtrack.jl
+++ b/src/grdtrack.jl
@@ -109,8 +109,13 @@ function grdtrack(cmd0::String="", arg1=nothing, arg2=nothing; kwargs...)
 		prj = isa(arg1, GMTgrid) ? arg1.proj4 : (isa(arg2, GMTgrid) ? arg2.proj4 : "")
 		is_geog = (contains(prj, "=longlat") || contains(prj, "=latlong")) ? true : false
 		(coln = (is_geog) ? ["Lon", "Lat"] : ["X", "Y"])
-		(size(R[1].data, 2) == 3) ? append!(coln, ["Z"]) : append!(coln, ["Z$(i-2)" for i=3:size(R[1].data, 2)])
-		for k = 1:length(R)  R[k].colnames = coln  end
+		if (isa(R, GMTdataset))
+			(size(R.data, 2) == 3) ? append!(coln, ["Z"]) : append!(coln, ["Z$(i-2)" for i=3:size(R.data, 2)])
+			R.colnames = coln
+		else
+			(size(R[1].data, 2) == 3) ? append!(coln, ["Z"]) : append!(coln, ["Z$(i-2)" for i=3:size(R[1].data, 2)])
+			for k = 1:length(R)  R[k].colnames = coln  end
+		end
 	end
 	R
 end

--- a/src/imshow.jl
+++ b/src/imshow.jl
@@ -48,7 +48,7 @@ function imshow(arg1, x::AbstractVector{Float64}=Vector{Float64}(), y::AbstractV
 		G = mat2img(arg1; kw...)
 	elseif (isGMTdataset(arg1) || (isa(arg1, Matrix{<:Real}) && size(arg1,2) <= 4))
 		ginfo = gmt("gmtinfo -C", arg1)
-		CTRL.limits[1:4] = ginfo[1].data[1:4]
+		CTRL.limits[1:4] = ginfo.data[1:4]
 		return plot(arg1; show=true, kw...)
 	else
 		G = mat2grid(arg1, x, y, reg=1)							# For displaying, pixel registration is more appropriate

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -512,7 +512,7 @@ function bar3(cmd0::String="", arg=nothing; first=true, kwargs...)
 		if ((val = find_in_dict(d, [:grd :grid])[1]) !== nothing)
 			arg1 = gmtread(cmd0, grd=true)
 		elseif ((val = find_in_dict(d, [:dataset :table])[1]) !== nothing)
-			arg1 = gmtread(cmd0, dataset=true);		arg1 = arg1[1]
+			arg1 = gmtread(cmd0, dataset=true)
 		else
 			error("BAR3: When first arg is a name, must also state its type. e.g. grd=true or dataset=true")
 		end
@@ -547,7 +547,7 @@ function bar3(cmd0::String="", arg=nothing; first=true, kwargs...)
 			(length(t) == 6) ? z_min = t[5] : error("For 3D cases, region must have 6 selements")
 		end
 		if (opt_base == "")  push!(d, :base => z_min)  end	# Make base = z_min
-		arg1 = gmt("grd2xyz", arg1)[1]			# Now arg1 is a GMTdataset
+		arg1 = gmt("grd2xyz", arg1)				# Now arg1 is a GMTdataset
 	else
 		opt_S = parse_I(d, "", [:S :width], "So", true)
 		if (opt_S == "")

--- a/src/proj_utils.jl
+++ b/src/proj_utils.jl
@@ -279,8 +279,13 @@ function buffergeo(line::Matrix{<:Real}; width=0, unit=:m, np=120, flatstart=fal
 	# line, but at this moment there seems to be an issue in GMT and distances are shorter. However we can
 	# do some cheap statistics to get read of the more inner points a get an almost perfec buffer.
 	Ddist2line = mapproject(D, L=(line=line, unit=:e))		# Find the distance from buffer points to input line
-	d_mean = mean(view(Ddist2line[1].data, :, 3))
-	ind = view(Ddist2line[1].data, :, 3) .>= d_mean
+	if (isa(Ddist2line, GMTdataset))
+		d_mean = mean(view(Ddist2line.data, :, 3))
+		ind = view(Ddist2line.data, :, 3) .>= d_mean
+	else
+		d_mean = mean(view(Ddist2line[1].data, :, 3))
+		ind = view(Ddist2line[1].data, :, 3) .>= d_mean
+	end
 	ind[1], ind[end] = true, true			# Ensure first and last are not removed
 	isa(D, GMTdataset) ? (D.data = D.data[ind, :]) : (D[1].data = D[1].data[ind, :])# Remove all points that are less 1% above the mean
 

--- a/src/pscontour.jl
+++ b/src/pscontour.jl
@@ -134,9 +134,9 @@ function contour(cmd0::String="", arg1=nothing; first=true, kwargs...)
 	if (!occursin(" -W", cmd) && !occursin(" -I", cmd) && !occursin(" -D", cmd))  cmd *= " -W"  end	# Use default pen
 
 	if (occursin("-I", cmd) && !occursin("-C", cmd))
-		r = round_wesn([info[1].data[5], info[1].data[6], info[1].data[5], info[1].data[6]])
-		info[1].data[5], info[1].data[6] = r[1], r[2]
-		opt_T = (isempty(current_cpt[1])) ? @sprintf(" -T%.14g/%.14g/11+n", info[1].data[5], info[1].data[6]) : ""
+		r = round_wesn([info.data[5], info.data[6], info.data[5], info.data[6]])
+		info.data[5], info.data[6] = r[1], r[2]
+		opt_T = (isempty(current_cpt[1])) ? @sprintf(" -T%.14g/%.14g/11+n", info.data[5], info.data[6]) : ""
 		if (N_used <= 1)
 			cmd, arg1, arg2, = add_opt_cpt(d, cmd, [:C], 'C', N_used, arg1, arg2, true, true, opt_T, true)
 		else

--- a/src/pshistogram.jl
+++ b/src/pshistogram.jl
@@ -163,7 +163,7 @@ function histogram(cmd0::String="", arg1=nothing; first=true, kwargs...)
 		got_min_max = true
 		if (is_datetime)
 			t = gmt("pshistogram -I -T" * opt_T, arg1)	# Call with inquire option to know y_min|max
-			h = round_wesn(t[1].data)					# Only h[4] is needed
+			h = round_wesn(t.data)					# Only h[4] is needed
 			opt_R *= sprintf("/0/%.12g", h[4])			# Half -R was computed in read_data()
 			cmd *= opt_R * " -T" * opt_T
 			opt_T = ""		# Clear it because the GMTimage & GMTgrid use a version without "-T" that is added at end

--- a/src/pstext.jl
+++ b/src/pstext.jl
@@ -99,7 +99,7 @@ function text(cmd0::String="", arg1=nothing; first=true, kwargs...)
 
 	# If file name sent in, read it and compute a tight -R if this was not provided
 	cmd, arg1, opt_R, = read_data(d, cmd0, cmd, arg1, opt_R)
-	if (isa(arg1, Array{<:Number}))
+	if (isa(arg1, Array{<:Real}))
 		arg1 = [GMTdataset(arg1, Float64[], Float64[], Dict{String, String}(), String[], String[], "", String[], "", "", 0)]
 	end
 

--- a/src/psxy.jl
+++ b/src/psxy.jl
@@ -380,6 +380,7 @@ function bar_group(d::Dict, cmd::String, opt_R::String, g_bar_fill::Array{String
 	# and as many rows in a segment as the number of groups (number of bars if groups had only one bar)
 	alpha = find_in_dict(d, [:alpha :fillalpha :transparency])[1]
 	_argD = mat2ds(_arg; fill=g_bar_fill, multi=do_multi, fillalpha=alpha)
+	isa(_argD, GMTdataset) && (_argD = [_argD])	# To simplify the algo (but introduce a type instability?)
 	(is_stack) && (_argD = ds2ds(_argD[1], fill=g_bar_fill, color_wrap=nl, fillalpha=alpha))
 	if (is_hbar && !is_stack)					# Must swap first & second col
 		for k = 1:length(_argD)

--- a/src/psxy.jl
+++ b/src/psxy.jl
@@ -292,8 +292,8 @@ function helper_multi_cols(d::Dict, arg1, mcc, opt_R, opt_S, opt_W, caller, is3D
 		end
 		if (penC != "")  cycle = [penC]  end
 		arg1 = mat2ds(arg1, color=cycle, ls=penS, multi=true)	# Convert to multi-segment GMTdataset
-		D::Vector{<:GMTdataset} = gmt("gmtinfo -C", arg1)		# But now also need to update the -R string
-		_cmd[1] = replace(_cmd[1], opt_R => " -R" * arg2str(round_wesn(D[1].data)))
+		D::GMTdataset = gmt("gmtinfo -C", arg1)		# But now also need to update the -R string
+		_cmd[1] = replace(_cmd[1], opt_R => " -R" * arg2str(round_wesn(D.data)))
 	elseif (!mcc && sub_module == "bar" && check_bar_group(arg1))	# !mcc because the bar-groups all have mcc = false
 		_cmd[1], arg1 = bar_group(d, _cmd[1], opt_R, g_bar_fill, got_Ebars, got_usr_R, arg1)
 	end
@@ -416,20 +416,20 @@ function bar_group(d::Dict, cmd::String, opt_R::String, g_bar_fill::Array{String
 
 	if (!got_usr_R)								# Need to recompute -R
 		info = gmt("gmtinfo -C", _argD)
-		(info[1].data[3] > 0) && (info[1].data[3] = 0)		# If not negative then must be 0
+		(info.data[3] > 0) && (info.data[3] = 0)		# If not negative then must be 0
 		if (!is_hbar)
-			dx = (info[1].data[2] - info[1].data[1]) * 0.005 + new_bw/2;
-			dy = (info[1].data[4] - info[1].data[3]) * 0.005;
-			info[1].data[1] -= dx;	info[1].data[2] += dx;	info[1].data[4] += dy;
-			(info[1].data[3] != 0) && (info[1].data[3] -= dy);
+			dx = (info.data[2] - info.data[1]) * 0.005 + new_bw/2;
+			dy = (info.data[4] - info.data[3]) * 0.005;
+			info.data[1] -= dx;	info.data[2] += dx;	info.data[4] += dy;
+			(info.data[3] != 0) && (info.data[3] -= dy);
 		else
-			dx = (info[1].data[2] - info[1].data[1]) * 0.005
-			dy = (info[1].data[4] - info[1].data[3]) * 0.005 + new_bw/2;
-			info[1].data[1] = 0.0;	info[1].data[2] += dx;	info[1].data[3] -= dy;	info[1].data[4] += dy;
-			(info[1].data[1] != 0) && (info[1].data[1] -= dx);
+			dx = (info.data[2] - info.data[1]) * 0.005
+			dy = (info.data[4] - info.data[3]) * 0.005 + new_bw/2;
+			info.data[1] = 0.0;	info.data[2] += dx;	info.data[3] -= dy;	info.data[4] += dy;
+			(info.data[1] != 0) && (info.data[1] -= dx);
 		end
-		info[1].data = round_wesn(info[1].data)		# Add a pad if not-tight
-		new_opt_R = sprintf(" -R%.15g/%.15g/%.15g/%.15g", info[1].data[1], info[1].data[2], info[1].data[3], info[1].data[4])
+		info.data = round_wesn(info.data)		# Add a pad if not-tight
+		new_opt_R = sprintf(" -R%.15g/%.15g/%.15g/%.15g", info.data[1], info.data[2], info.data[3], info.data[4])
 		cmd = replace(cmd, opt_R => new_opt_R)
 	end
 	return cmd, _argD
@@ -443,11 +443,11 @@ function recompute_R_4bars!(cmd::String, opt_R::String, arg1)
 	(sub_b != "") && (opt_S = opt_S[1:ind[1]-1])# Strip it because we need to (re)find Bar width
 	bw = (isletter(opt_S[end])) ? parse(Float64, opt_S[3:end-1]) : parse(Float64, opt_S[2:end])	# Bar width
 	info = gmt("gmtinfo -C", arg1)
-	dx::Float64 = (info[1].data[2] - info[1].data[1]) * 0.005 + bw/2;
-	dy::Float64 = (info[1].data[4] - info[1].data[3]) * 0.005;
-	info[1].data[1] -= dx;	info[1].data[2] += dx;	info[1].data[4] += dy;
-	info[1].data = round_wesn(info[1].data)		# Add a pad if not-tight
-	new_opt_R = sprintf(" -R%.15g/%.15g/%.15g/%.15g", info[1].data[1], info[1].data[2], 0, info[1].data[4])
+	dx::Float64 = (info.data[2] - info.data[1]) * 0.005 + bw/2;
+	dy::Float64 = (info.data[4] - info.data[3]) * 0.005;
+	info.data[1] -= dx;	info.data[2] += dx;	info.data[4] += dy;
+	info.data = round_wesn(info.data)		# Add a pad if not-tight
+	new_opt_R = sprintf(" -R%.15g/%.15g/%.15g/%.15g", info.data[1], info.data[2], 0, info.data[4])
 	cmd = replace(cmd, opt_R => new_opt_R)
 end
 

--- a/src/utils_project.jl
+++ b/src/utils_project.jl
@@ -5,7 +5,7 @@ function geodetic2enu(lon, lat, h, lon0, lat0, h0)
 	#
 	D1 = mapproject([lon lat h], geod2ecef=true);
 	D0 = mapproject([lon0 lat0 h0], geod2ecef=true);
-	d  = D1[1].data .- D0[1].data;
+	d  = D1.data .- D0.data;
 	xEast, yNorth, zUp = ecef2enuv(view(d, :, 1), view(d, :, 2), view(d, :, 3), lon0, lat0)
 end
 

--- a/src/utils_types.jl
+++ b/src/utils_types.jl
@@ -188,7 +188,7 @@ function mat2ds(mat, txt::Vector{String}=String[]; hdr=String[], geom=0, kwargs.
 		end
 	end
 	set_dsBB!(D)				# Compute and set the global BoundingBox for this dataset
-	return D
+	return (length(D) == 1 && !multi) ? D[1] : D		# Drop the damn Vector singletons
 end
 
 # ---------------------------------------------------------------------------------------------------

--- a/test/test_B-GMTs.jl
+++ b/test/test_B-GMTs.jl
@@ -1,9 +1,9 @@
 	println("	GMTINFO")
 	gmt("gmtset -");
 	r = gmt("gmtinfo -C", ones(Float32,9,3)*5);
-	@assert(r[1].data == [5.0 5 5 5 5 5])
+	@assert(r.data == [5.0 5 5 5 5 5])
 	r = gmtinfo(ones(Float32,9,3)*5, C=true, V=:q);
-	@assert(r[1].data == [5.0 5 5 5 5 5])
+	@assert(r.data == [5.0 5 5 5 5 5])
 	#gmtinfo(help=0)
 
 	println("	BLOCK*s")
@@ -90,7 +90,7 @@
 	# GMTSPATIAL
 	# Test  Cartesian centroid and area
 	result = gmt("gmtspatial -Q", [0 0; 1 0; 1 1; 0 1; 0 0]);
-	@assert(isapprox(result[1].data, [0.5 0.5 1]))
+	@assert(isapprox(result.data, [0.5 0.5 1]))
 	# Test Geographic centroid and area
 	result = gmt("gmtspatial -Q -fg", [0 0; 1 0; 1 1; 0 1; 0 0]);
 	# Intersections
@@ -159,7 +159,7 @@
 	gmtwrite("lixo.dat", convert.(UInt8, [1 2 3; 2 3 4]))
 	gmtwrite("lixo.dat", [1 2 10; 3 4 20])
 	D = gmtread("lixo.dat", i="0,1s10", table=true);
-	@test(sum(D[1].data) == 64.0)
+	@test(sum(D.data) == 64.0)
 	gmtwrite("lixo.dat", D)
 	gmt("gmtwrite lixo.cpt", cpt)		# Same but tests other code chunk in gmt_main.jl
 	gmt("gmtwrite lixo.dat", D)

--- a/test/test_GRDs.jl
+++ b/test/test_GRDs.jl
@@ -1,9 +1,9 @@
 	println("	GRDINFO")
 	G=gmt("grdmath", "-R0/10/0/10 -I1 5");
 	r=gmt("grdinfo -C", G);
-	@assert(r[1].data[1:1,1:10] == [0.0  10.0  0.0  10.0  5.0  5.0  1.0  1.0  11.0  11.0])
+	@assert(r.data[1:1,1:10] == [0.0  10.0  0.0  10.0  5.0  5.0  1.0  1.0  11.0  11.0])
 	r2=grdinfo(G, C=true, V=:q);
-	@assert(r[1].data == r2[1].data)
+	@assert(r.data == r2.data)
 	grdinfo(mat2grid(rand(4,4)));				# Test the doubles branch in grid_init
 	grdinfo(mat2grid(rand(Float32,4,4)));		# Test the float branch in grid_init
 	nx = 3; ny = 2; rang = [1, nx, 1, ny, 0.0,1]; x = collect(1.0:nx); y = collect(1.0:ny); inc = [1.0, 1];
@@ -21,7 +21,7 @@
 	gmtwrite("lixo.grd", G)
 	D1=grd2xyz(G);
 	D2=grd2xyz("lixo.grd");
-	@assert(sum(D1[1].data) == sum(D2[1].data))
+	@assert(sum(D1.data) == sum(D2.data))
 
 	println("	GRD2KML")
 	G=gmt("grdmath", "-R0/10/0/10 -I1 X -fg");
@@ -39,12 +39,12 @@
 	println("	GRDCONTOUR")
 	G = gmt("grdmath -R-15/15/-15/15 -I0.3 X Y HYPOT DUP 2 MUL PI MUL 8 DIV COS EXCH NEG 10 DIV EXP MUL =");
 	C = grdcontour(G, C="+0.7", D=[]);
-	@assert((size(C[1].data,1) == 21) && abs(-0.6 - C[1].data[1,1]) < 1e-8)
+	@assert((size(C.data,1) == 21) && abs(-0.6 - C.data[1,1]) < 1e-8)
 	# Do the same but write the file on disk first
 	gmt("write lixo.grd", G)
 	GG = gmt("read -Tg lixo.grd");
 	C = grdcontour("lixo.grd", C="+0.7", D=[]);
-	@assert((size(C[1].data,1) == 21) && abs(-0.6 - C[1].data[1,1]) < 1e-8)
+	@assert((size(C.data,1) == 21) && abs(-0.6 - C.data[1,1]) < 1e-8)
 	r = grdcontour("lixo.grd", cont=10, A=(int=50,labels=(font=7,)), G=(dist="4i",), L=(-1000,-1), W=((contour=1,pen="thinnest,-"), (annot=1, pen="thin,-")), T=(gap=("0.1i","0.02i"),), Vd=dbg2);
 	@test startswith(r, "grdcontour lixo.grd  -JX" * split(GMT.def_fig_size, '/')[1] * "/0" * " -Baf -BWSen -L-1000/-1 -A50+f7 -Gd4i -T+d0.1i/0.02i -Wcthinnest,- -Wathin,- -R-15/15/-15/15 -C10")
 	r = grdcontour("lixo.grd", A="50+f7p", G="d4i", W=((contour=1,pen="thinnest,-"), (annot=1, pen="thin,-")), Vd=dbg2);
@@ -136,14 +136,14 @@
 	G = gmt("grdmath -R-2/2/-2/2 -I1 1");
 	gmtwrite("lixo.grd", G)
 	D = grdtrack([0 0], G);
-	@assert(D[1].data == [0.0 0 1])
+	@assert(D.data == [0.0 0 1])
 	D = grdtrack([0 0], G="lixo.grd");
-	@assert(D[1].data == [0.0 0 1])
+	@assert(D.data == [0.0 0 1])
 	D = grdtrack("lixo.grd", [0 0]);
 	D = grdtrack(G, [0 0]);
 	D = grdtrack([0 0], G=G);
 	D = grdtrack([0 0], G=(G,G));
-	@assert(D[1].data == [0.0 0 1 1])
+	@assert(D.data == [0.0 0 1 1])
 
 	println("	GRDVECTOR")
 	G = gmt("grdmath -R-2/2/-2/2 -I0.1 X Y R2 NEG EXP X MUL");

--- a/test/test_GRDs.jl
+++ b/test/test_GRDs.jl
@@ -66,7 +66,7 @@
 	im = mat2img(UInt8.(GMT.magic(9)))
 	D = mat2ds([1.6 2.6; 1.6 4.4; 4.4 4.4; 4.4 2.6; 1.6 2.6])
 	crop(im, region=D)[1].image == UInt8.([27 29 40; 28 39 50])
-	colorzones!(D, img=im)		# A bit out of place but it reuses the variables above
+	colorzones(D, img=im)		# A bit out of place but it reuses the variables above
 	G = GMT.peaks();
 	D = mat2ds([-1 -1; 1 1; 1 -1; -1 -1]);
 	GMT.rasterzones!(G, D, mean)

--- a/test/test_gd_ext.jl
+++ b/test/test_gd_ext.jl
@@ -8,9 +8,9 @@
 	@test I.proj4 == "+proj=longlat"
 
 	bf = buffer([0 0], 1)
-	@test bf[1].geom == Gdal.wkbPolygon
+	@test bf.geom == Gdal.wkbPolygon
 	c = centroid(bf)
-	#@test c[1].data ≈ [0. 0.]
+	#@test c.data ≈ [0. 0.]
 	bf2 = buffer([0.5 0], 1);
 	polyunion(bf, bf2);
 	Gdal.difference(bf, bf2);
@@ -31,14 +31,14 @@
 	Gdal.envelope3d(bf);
 	Gdal.boundary(bf);
 	Gdal.convexhull(bf);
-	bf[1].geom = wkbLineString;
+	bf.geom = wkbLineString;
 	Gdal.pointalongline(bf, 0.3);
 	g1 = fromWKT("MULTIPOINT(0 0, 10 0, 10 10, 11 10)");
 	g2 = delaunay(g1,2.0,true);
 	@test toWKT(g2) == "MULTILINESTRING ((0 0,10 10),(0 0,10 0),(10 0,10 10))"
 	D1 = mat2ds([0 0;10 0;10 10;11 10], geom=wkbMultiPoint);
 	g2 = delaunay(D1,2.0,true, gdataset=true);		# Doesn't error but returns MULTILINESTRING EMPTY 
-	@test length(Gdal.simplify([0. 0; 1 1.1; 2.1 2], 0.2)[1]) == 4
+	@test length(Gdal.simplify([0. 0; 1 1.1; 2.1 2], 0.2)) == 4
 	
 	D1 = mat2ds([0 0; 10 0; 10 10; 11 10]);
 	gdalwrite("lixo1.gmt", D1);
@@ -93,20 +93,20 @@
 	@test xy2lonlat([111319.49079327357 110579.96522189621], s_srs="+proj=merc") ≈ [1 1]
 	@test xy2lonlat([111319.49079327357 110579.96522189621], s_srs=3395) ≈ [1 1]
 		
-	@test xy2lonlat(mat2ds([111319.49079327357 110579.96522189621]), s_srs=3395)[1].data ≈ [1 1]
-	@test xy2lonlat(mat2ds([111319.49079327357 110579.96522189621]), s_srs="+proj=merc")[1].data ≈ [1 1]
+	@test xy2lonlat(mat2ds([111319.49079327357 110579.96522189621]), s_srs=3395).data ≈ [1 1]
+	@test xy2lonlat(mat2ds([111319.49079327357 110579.96522189621]), s_srs="+proj=merc").data ≈ [1 1]
 		
-	@test xy2lonlat(mat2ds([111319.49079327357 110579.96522189621])[1], s_srs="+proj=merc").data ≈ [1 1]
-	@test xy2lonlat(mat2ds([111319.49079327357 110579.96522189621])[1], s_srs=3395).data ≈ [1 1]
+	@test xy2lonlat(mat2ds([111319.49079327357 110579.96522189621]), s_srs="+proj=merc").data ≈ [1 1]
+	@test xy2lonlat(mat2ds([111319.49079327357 110579.96522189621]), s_srs=3395).data ≈ [1 1]
 		
 	@test xy2lonlat([111319.49079327357, 110579.96522189621], s_srs="+proj=merc") ≈ [1, 1]
 	@test xy2lonlat([111319.49079327357, 110579.96522189621], s_srs=3395) ≈ [1, 1]
 	@test xy2lonlat([111319.49079327357, 110579.96522189621], 3395) ≈ [1, 1]
 
-	@test lonlat2xy(mat2ds([1 1]), t_srs="+proj=merc")[1].data ≈ [111319.49079327357 110579.96522189621]
-	@test lonlat2xy(mat2ds([1 1]), t_srs=3395)[1].data ≈ [111319.49079327357 110579.96522189621]
-	@test lonlat2xy(mat2ds([1 1]), 3395)[1].data ≈ [111319.49079327357 110579.96522189621]
-	@test lonlat2xy(mat2ds([1 1])[1], t_srs=3395).data ≈ [111319.49079327357 110579.96522189621]
+	@test lonlat2xy(mat2ds([1 1]), t_srs="+proj=merc").data ≈ [111319.49079327357 110579.96522189621]
+	@test lonlat2xy(mat2ds([1 1]), t_srs=3395).data ≈ [111319.49079327357 110579.96522189621]
+	@test lonlat2xy(mat2ds([1 1]), 3395).data ≈ [111319.49079327357 110579.96522189621]
+	@test lonlat2xy(mat2ds([1 1]), t_srs=3395).data ≈ [111319.49079327357 110579.96522189621]
 
 	@test lonlat2xy([1 1], t_srs="+proj=merc") ≈ [111319.49079327357 110579.96522189621]
 	@test lonlat2xy([1 1], t_srs=3395) ≈ [111319.49079327357 110579.96522189621]

--- a/test/test_gdal.jl
+++ b/test/test_gdal.jl
@@ -217,7 +217,7 @@ Gdal.GDALDestroyDriverManager()
 
 	#Gdal.identifydriver("lixo.gmt")
 	D = mat2ds([-8. 37.0; -8.1 37.5; -8.5 38.0], proj="+proj=longlat");
-	ds = gmt2gd(D[1])
+	ds = gmt2gd(D)
 	ds = gmt2gd(D, geometry="Polygon")
 	gmt2gd(mat2ds([0 10; 1 11; 0 10], x=[0, 1, 2], multi=true), geometry="line")
 	gmt2gd(mat2ds([0 10; 1 11; 0 10; 0 10], x=[0, 1, 2, 0], multi=true), geometry="polyg")
@@ -227,7 +227,7 @@ Gdal.GDALDestroyDriverManager()
 	ds2=ogr2ogr(ds, ["-t_srs", "+proj=utm +zone=29", "-overwrite"])
 	gd2gmt(ds2)
 	ogr2ogr(D, "-t_srs '+proj=utm +zone=29' -overwrite")	# Returns a GMT datset directly
-	ogr2ogr(D[1], "-t_srs '+proj=utm +zone=29' -overwrite")
+	#ogr2ogr(D[1], "-t_srs '+proj=utm +zone=29' -overwrite")
 
 	D1 = mat2ds([0.0 0.0; 1.0 1.0; 1.0 0.0; 0.0 0.0]);
 	gmt2gd(D1);		gmt2gd(D1, geometry="line");	gmt2gd(D1, geometry="point")

--- a/test/test_proj4.jl
+++ b/test/test_proj4.jl
@@ -5,7 +5,7 @@
 	geod([0, 0], [30 60], 111000)
 	geod([0, 0], 30, [50, 111], unit=:k)
 	geod([0, 0], [30 60], [50, 111], unit=:k)
-	geod([0., 0], [15., 45], [[0, 10000, 50000, 111000.], [0., 50000]])[1]
+	geod([0., 0], [15., 45], [[0, 10000, 50000, 111000.], [0., 50000]])
 	invgeod([0., 0], [1., 0])
 	@test_throws ErrorException("'azimuth' MUST be either a scalar or a 1-dim array, and 'distance' may also be a Vector{Vector}") geod([0, 0], [30 8; 1 1], [50 111], unit=:k)
 	GMT.proj_info()
@@ -15,7 +15,7 @@
 	@test circgeo(0.,0, radius=50, dataset=true, unit=:k).data[1] == 0.0
 	@test_throws ErrorException("Bad shape name (a)") circgeo(0.,0, radius=50, shape=:a)
 	circgeo([0 0; 0 2], radius=50, unit=:k)
-	buffergeo(mat2ds([0 0; 5 5])[1], width=100, unit=:k, tol=0)
+	buffergeo(mat2ds([0 0; 5 5]), width=100, unit=:k, tol=0)
 	buffergeo(mat2ds([178 73; -175 74]), width=100, unit=:k)
 	wkt = epsg2wkt(4326)
 	prj = epsg2proj(4326)
@@ -23,10 +23,10 @@
 	wkt2proj(wkt)
 	loxo = loxodrome_direct(0,0,45, 10000)
 	loxo = loxodrome([0 0; 30 50], step=500, unit=:k);
-	loxo = loxodrome(mat2ds([0 0; 30 50])[1], step=500, unit=:k);
+	loxo = loxodrome(mat2ds([0 0; 30 50]), step=500, unit=:k);
 	loxo = loxodrome(0, 0, 30, 50, step=500, unit=:k);
 	orto = orthodrome(mat2ds([0 0; 30 50]), step=500, unit=:k);
-	orthodrome(mat2ds([0 0; 15 25; 30 50])[1], step=500, unit=:k)
+	orthodrome(mat2ds([0 0; 15 25; 30 50]), step=500, unit=:k)
 	orthodrome(0, 0, 30, 50, step=500, unit=:k);
 	dist, azim = GMT.loxodrome_inverse(0,0,5,5)
 end


### PR DESCRIPTION
This avoids the annoying practice of having to refer to ``D[1]`` almost all times instead of simply ``D``