### PR TITLE
Shrink the share/custom symbol path by 5 chars. May make the difference.

### DIFF
--- a/src/choropleth_utils.jl
+++ b/src/choropleth_utils.jl
@@ -17,8 +17,9 @@ function cpt4dcw(codes::Vector{<:AbstractString}, vals::Vector{<:Real}; kwargs..
 	elseif ((val = find_in_dict(d, [:range])[1]) !== nothing && isvector(val) && length(val) >= 2)
 		inc = (length(val) == 2) ? 1 : val[3]
 		C = makecpt(T=(val[1], val[2], inc))
+		#C = gmt("makecpt -T" * arg2str((val[1], val[2], inc)))
 	else
-		C = makecpt(T=(0,255,1))
+		C = gmt("makecpt -T0/255/1")
 	end
 
 	p = sortperm(vals)		# Need to have the 'vals' sorted otherwise if we plot the CPT we get a mess
@@ -32,7 +33,7 @@ function cpt4dcw(codes::Vector{<:AbstractString}, vals::Vector{<:Real}; kwargs..
 	while(_vals[k] > C.minmax[2] && k > 0)        c[k] = false;  k -= 1  end
 	_codes, _vals = _codes[c], _vals[c]
 
-	GC.@preserve P::Ptr{GMT.GMT_PALETTE} = palette_init(G_API[1], C);		# A pointer to a GMT CPT
+	P::Ptr{GMT.GMT_PALETTE} = palette_init(G_API[1], C);		# A pointer to a GMT CPT
 
 	Ccat::GMTcpt = makecpt(T=join(_codes, ","));
 	rgb = [0.0, 0.0, 0.0];

--- a/src/psxy.jl
+++ b/src/psxy.jl
@@ -797,7 +797,7 @@ function seek_custom_symb(marca::String, with_k::Bool=false)::Tuple{String, Stri
 	# The WITH_K arg is to allow calling this fun with a sym name already prefaced with 'k', or not
 	(with_k && marca[1] != 'k') && return marca, ""		# Not a custom symbol, return what we got.
 
-	cus_path = joinpath(dirname(pathof(GMT)), "..", "share", "custom")
+	cus_path = joinpath(dirname(pathof(GMT))[1:end-4], "share", "custom")
 	cus = readdir(cus_path)						# Get the list of all custom symbols in this dir.
 	s = split(marca, '/')
 	ind_s = with_k ? 2 : 1
@@ -806,6 +806,7 @@ function seek_custom_symb(marca::String, with_k::Bool=false)::Tuple{String, Stri
 		_mark = splitext(r[1])[1]				# Get the marker name but without extension
 		_siz  = split(marca, '/')[2]			# The custom symbol size
 		_marca = (with_k ? "k" : "")  * joinpath(cus_path, _mark) * "/" * _siz
+		(GMTver <= v"6.4" && (length(_marca) - length(_siz) -2) > 62) && warn("Due to a GMT <= 6.4 limitation the length of full (name+path) custom symbol name cannot be longer than 62 bytes.")
 		return _marca, r[1]
 	end
 	return marca, ""							# A custom symbol from the official GMT collection.


### PR DESCRIPTION
GMT6.4 has a limitation of 64 bytes for the full custom symbol file name.