### PR TITLE
Avoid using makecpt(T=string) and use gmt("makecpt -Tstring").

### DIFF
--- a/src/choropleth_utils.jl
+++ b/src/choropleth_utils.jl
@@ -16,8 +16,7 @@ function cpt4dcw(codes::Vector{<:AbstractString}, vals::Vector{<:Real}; kwargs..
 		C = val
 	elseif ((val = find_in_dict(d, [:range])[1]) !== nothing && isvector(val) && length(val) >= 2)
 		inc = (length(val) == 2) ? 1 : val[3]
-		C = makecpt(T=(val[1], val[2], inc))
-		#C = gmt("makecpt -T" * arg2str((val[1], val[2], inc)))
+		C = gmt("makecpt -T" * arg2str((val[1], val[2], inc)))
 	else
 		C = gmt("makecpt -T0/255/1")
 	end
@@ -33,9 +32,9 @@ function cpt4dcw(codes::Vector{<:AbstractString}, vals::Vector{<:Real}; kwargs..
 	while(_vals[k] > C.minmax[2] && k > 0)        c[k] = false;  k -= 1  end
 	_codes, _vals = _codes[c], _vals[c]
 
-	P::Ptr{GMT.GMT_PALETTE} = palette_init(G_API[1], C);		# A pointer to a GMT CPT
+	P::Ptr{GMT.GMT_PALETTE} = palette_init(G_API[1], C)			# A pointer to a GMT CPT
 
-	Ccat::GMTcpt = makecpt(T=join(_codes, ","));
+	Ccat::GMTcpt = gmt("makecpt -T"*join(_codes, ","))
 	rgb = [0.0, 0.0, 0.0];
 
 	inc = (C.minmax[2] - C.minmax[1]) / size(Ccat.cpt, 1)

--- a/src/utils_types.jl
+++ b/src/utils_types.jl
@@ -364,7 +364,7 @@ function line2multiseg(M::Matrix{<:Real}; is3D::Bool=false, color::GMTcpt=GMTcpt
 	if (isempty(color) && auto_color)
 		mima = (size(M,2) <= 3) ? (1., Float64(size(M,1))) : extrema(view(M, :, color_col))
 		(size(M,2) <= 3) && (use_row_number = true; z4color = 1.:n_ds)
-		color::GMTcpt = makecpt(@sprintf("-T%f/%f/65+n -Cturbo -Vq", mima[1]-eps(1e10), mima[2]+eps(1e10)))
+		color::GMTcpt = gmt("makecpt " * @sprintf("-T%f/%f/65+n -Cturbo -Vq", mima[1]-eps(1e10), mima[2]+eps(1e10)))
 	end
 
 	if (!isempty(color))


### PR DESCRIPTION
This is utterly weird but avoiding the parsing of T=string seems to make makecpt crashes go away. It makes no sense because there is almost no parsing in this case.