### PR TITLE
Modify gmtbinstats to allow some specific tesrs to pass.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
           - '1.7' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
           - 'nightly'
         os:
-          - ubuntu-latest
-          #- ubuntu-18.04
+          #- ubuntu-latest
+          - ubuntu-20.04
           - macos-latest
         arch:
           - x64

--- a/src/gmtbinstats.jl
+++ b/src/gmtbinstats.jl
@@ -61,7 +61,6 @@ Parameters
 function binstats(cmd0::String="", arg1=nothing; kwargs...)
 
 	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
-	#(haskey(d, :Vd) && d[:Vd] == 2)
 	(cmd0 != "") && (arg1 = read_data(d, cmd0, "", arg1, " ", false, true)[2])	# Make sure we have the data here
 	data = mat2ds(arg1)
 	isa(data, Vector{<:GMTdataset}) && isempty(data[1].ds_bbox) && set_dsBB!(data)

--- a/test/test_B-GMTs.jl
+++ b/test/test_B-GMTs.jl
@@ -90,8 +90,8 @@
 	if (GMTver > v"6.3.0")		# Before it was bugged.
 		gmtbinstats("@capitals.gmt", a="2=population", R=:g, I=5, C=:z, S="1000k");
 		gmtbinstats("@capitals.gmt", aspatial="2=population", R=:g, I=5, C="q10", search_radius="1000k", Vd=dbg2);
-		@test_throws ErrorException("Bad argument for the 'tile' option (vv)") gmtbinstats("lixo", R=:g, I=5, C="vv")
-		#@test gmtbinstats("lixo", R=:g, I=5, tiling=:hexagon, stats=:n, Vd=2) == "gmtbinstats lixo  -I5 -Rg -Cn -Th"
+		@test_throws ErrorException("Bad argument for the 'tile' option (vv)") gmtbinstats("@capitals.gmt", R=:g, I=5, C="vv")
+		@test gmtbinstats("@capitals.gmt", R=:g, I=5, tiling=:hexagon, stats=:n, Vd=2) == "gmtbinstats @capitals.gmt  -I5 -Rg -Cn -Th"
 		gmt("destroy")
 		xy = rand(100,2) .* [5 3];
     	D = gmtbinstats(xy, region=(0,5,0,3), inc=1, tiling=:hex, stats=:number, f=:c);


### PR DESCRIPTION
Downgrade GH-action Ubuntu to 20.04 to avoid the libstdc++ big shit.