### PR TITLE
Fix bug where -b option was been passed twice. 

### DIFF
--- a/src/common_options.jl
+++ b/src/common_options.jl
@@ -1280,14 +1280,14 @@ function parse_a(d::Dict, cmd::String)
 end
 
 # ---------------------------------------------------------------------------------------------------
-function parse_b(d::Dict, cmd::String, symbs::Array{Symbol}=[:b :binary])
+function parse_b(d::Dict, cmd::String, symbs::Array{Symbol}=[:b :binary], io::String="")
 	# Parse the global -b option. Return CMD same as input if no -b option in args
-	cmd_ = add_opt(d, "", string(symbs[1]), symbs, 
+	cmd_ = add_opt(d, "", string(symbs[1])*io, symbs, 
 	               (ncols=("", arg2str, 1), type=("", data_type, 2), swapp_bytes="_w", little_endian="_+l", big_endian="+b"))
 	return cmd * cmd_, cmd_
 end
-parse_bi(d::Dict, cmd::String) = parse_b(d, cmd, [:bi :binary_in])
-parse_bo(d::Dict, cmd::String) = parse_b(d, cmd, [:bo :binary_out])
+parse_bi(d::Dict, cmd::String) = parse_b(d, cmd, [:b :bi :binary_in],  "i")
+parse_bo(d::Dict, cmd::String) = parse_b(d, cmd, [:b :bo :binary_out], "o")
 # ---------------------------------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------------------------------

--- a/src/gmtreadwrite.jl
+++ b/src/gmtreadwrite.jl
@@ -141,7 +141,6 @@ function gmtread(fname::String; kwargs...)
 	end
 
 	if (opt_T != " -To")			# All others but OGR
-		if (opt_T == " -Td" && opt_bi != "")  cmd *= opt_bi  end		# Read from binary file
 		cmd *= opt_T
 		#return (dbg_print_cmd(d, cmd) !== nothing) ? "gmtread " * cmd : gmt("read " * fname * cmd)
 		(dbg_print_cmd(d, cmd) !== nothing) && return "gmtread " * cmd

--- a/src/psxy.jl
+++ b/src/psxy.jl
@@ -64,6 +64,7 @@ function common_plot_xyz(cmd0::String, arg1, caller::String, first::Bool, is3D::
 		def_J = (is_ternary) ? " -JX" * split(def_fig_size, '/')[1] : ""		# Gives "-JX14c" 
 		(!is_ternary && isa(arg1, GMTdataset) && length(arg1.ds_bbox) >= 4) && (CTRL.limits[1:4] = arg1.ds_bbox[1:4])
 		(!is_ternary && isa(arg1, Vector{<:GMTdataset}) && length(arg1[1].ds_bbox) >= 4) && (CTRL.limits[1:4] = arg1[1].ds_bbox[1:4])
+		(!is_ternary && isa(arg1, GDtype)) && (CTRL.limits[7:10] = CTRL.limits[1:4])	# Start with plot=data limits
 		(!IamModern[1] && haskey(d, :hexbin) && !haskey(d, :aspect)) && (d[:aspect] = :equal)	# Otherwise ... gaps between hexagons
 		if (is_ternary)  cmd, opt_J = parse_J(d, cmd, def_J)
 		else             cmd, opt_B, opt_J, opt_R = parse_BJR(d, cmd, caller, O, def_J)


### PR DESCRIPTION
  Improve the parse_b() usage. Now bi=... comes out directly as -bi...