### PR TITLE
Use temporary names containg the user name.

### DIFF
--- a/src/GMT.jl
+++ b/src/GMT.jl
@@ -43,7 +43,8 @@ const GMTdevdate = ((ind = findlast('_', out)) === nothing) ? Date("0001-01-01")
 const GMTver, libgmt, libgdal, libproj, GMTuserdir = _GMTver, _libgmt, _libgdal, _libproj, [userdir]
 
 const global G_API = [C_NULL]
-const global PSname = [joinpath(tempdir(), "GMTjl_tmp.ps")]		# The PS file where, in classic mode, all lands.
+const global PSname = [""]					# The PS file (filled in __init__) where, in classic mode, all lands.
+const global tmpdir_usr = [tempdir(), ""]	# Save the tmp dir and user name (also filled in __init__)
 const global img_mem_layout = [""]			# "TCP"	 For Images.jl. The default is "TRBa"
 const global grd_mem_layout = [""]			# "BRP" is the default for GMT PS images.
 const global current_view   = [""]			# To store the current viewpoint (-p)
@@ -282,7 +283,7 @@ import SnoopPrecompile
 	GMT.cat_2_arg2(rand(3), mat2ds(rand(3,2)));
 	GMT.cat_2_arg2(mat2ds(rand(3,2)), mat2ds(rand(3,2)));
 	GMT.cat_3_arg2(rand(3),rand(3),rand(3));
-	plot(rand(5,2), marker=:point, lc=:red, ls=:dot, lw=1, C=:jet, colorbar=true)
+	plot(rand(5,2), marker=:point, lc=:red, ls=:dot, lw=1, C=:jet, colorbar=true, Vd=2)
 	plot(rand(5,2))
 	violin(rand(50))
 	boxplot(rand(50))
@@ -312,6 +313,9 @@ function __init__(test::Bool=false)
 	f = joinpath(GMTuserdir[1], "theme_jl.txt")
 	(isfile(f)) && (theme(readline(f));	ThemeIsOn[1] = false)	# False because we don't want it reset in showfig()
 	(GMTver < v"6.2.0") && extra_sets()		# some calls to gmtlib_setparameter() (theme_modern already called this)
+	user = (Sys.isunix() || Sys.isapple()) ? Libc.getpwuid(Libc.getuid(), true).username : Sys.iswindows() ? ENV["USERNAME"] : ""
+	tmpdir_usr[2] = replace(user, " " => "_")
+	PSname[1] = tmpdir_usr[1] * "/" * "GMTjl_" * tmpdir_usr[2] * ".ps"
 end
 
 #include("precompile_GMT_i.jl")

--- a/src/common_options.jl
+++ b/src/common_options.jl
@@ -3004,9 +3004,9 @@ function helper3_axes(arg, primo::String, axe::String)::String
 		@warn("Argument of the custom annotations must be an N-array or a NamedTuple");		return ""
 	end
 
-	temp::String = "GMTjl_custom_" * primo
+	temp::String = "GMTjl_custom_" * primo * "_" * tmpdir_usr[2]
 	(axe != "") && (temp *= axe)
-	fname = joinpath(tempdir(), temp * ".txt")
+	fname = joinpath(tmpdir_usr[1], temp * ".txt")
 	fid = open(fname, "w")
 	if (label != [""])
 		for k = 1:n_annot
@@ -3260,7 +3260,7 @@ function helper_decorated(d::Dict, compose=false)
 	elseif ((val = find_in_dict(d, [:locations])[1]) !== nothing)
 		if (isa(val, AbstractString))  cmd = val
 		elseif (GMTver < v"6.4.0" && (isa(val, Matrix) || isa(val, GDtype)))
-			cmd = joinpath(tempdir(), "GMTjl_decorated_loc.dat")
+			cmd = joinpath(tmpdir_usr[1], "GMTjl_decorated_loc_" * tmpdir_usr[2] * ".dat")
 			gmtwrite(cmd, val)
 		end
 		optD = "f"
@@ -3351,7 +3351,7 @@ end
 
 # ---------------------------------------------------------------------------------------------------
 function fname_out(d::Dict, del::Bool=false)
-	# Create a file name in the TMP dir when OUT holds only a known extension. The name is: GMTjl_tmp.ext
+	# Create a file name in the TMP dir when OUT holds only a known extension. The name is: GMT_user.ext
 
 	EXT::String = FMT[1];	fname::AbstractString = ""
 	if ((val = find_in_dict(d, [:savefig :figname :name], del)[1]) !== nothing)
@@ -3391,7 +3391,7 @@ function fname_out(d::Dict, del::Bool=false)
 	end
 
 	(fname != "") && (fname *= "." * EXT)
-	def_name::String = PSname[1]		# "GMTjl_tmp.ps" in TMP dir
+	def_name::String = PSname[1]		# "GMT_user.ps" in TMP dir
 	return def_name, opt_T, EXT, fname, ret_ps
 end
 
@@ -4191,7 +4191,7 @@ end
 """
     append2fig(fname::String)
 
-Move the file `fname` to the default name and location (GMTjl_tmp.ps in tmp). The `fname` should be
+Move the file `fname` to the default name and location (GMT_user.ps in tmp). The `fname` should be
 a PS file that has NOT been closed. Posterior calls to plotting methods will append to this file.
 Useful when creating figures that use a common base map that may be heavy (slow) to compute.
 """

--- a/src/gdal_tools.jl
+++ b/src/gdal_tools.jl
@@ -120,7 +120,7 @@ function helper_run_GDAL_fun(f::Function, indata, dest::String, opts, method::St
 	# For gdaldem color-relief we need a further arg that is the name of a cpt. So save one on disk
 	_cmap = C_NULL
 	if (f == gdaldem && ((cmap = GMT.find_in_dict(d, GMT.CPTaliases)[1])) !== nothing)
-		_cmap = tempdir() * "/GMTtmp_cpt.cpt"
+		_cmap = GMT.tmpdir_usr[1] * "/GMTjl_cpt_" * GMT.tmpdir_usr[2] * ".cpt"
 		if ( (isa(cmap, String) && (lowercase(splitext(cmap)[2][2:end]) == "cpt")) || isa(cmap, GMT.GMTcpt) )
 			save_cpt4gdal(cmap, _cmap)	# GDAL pretend to recognise CPTs but it almost doesn't
 		else

--- a/src/gmt_main.jl
+++ b/src/gmt_main.jl
@@ -190,7 +190,8 @@ function gmt(cmd::String, args...)
 	g_module::String, r = strtok(cmd)
 
 	if (g_module == "begin")			# Use this default fig name instead of "gmtsession"
-		(r == "") && (r = isFranklin[1] ? (joinpath(tempdir(), "GMTjl_tmp png")) : "GMTplot " * FMT[1]::String)
+		#(r == "") && (r = isFranklin[1] ? (joinpath(tempdir(), "GMTjl_tmp png")) : "GMTplot " * FMT[1]::String)
+		(r == "") && (r = isFranklin[1] ? (tmpdir_usr[1] * "/" * "GMTjl_" * tmpdir_usr[2] * " png") : "GMTplot " * FMT[1]::String)
 		IamModern[1] = true
 	elseif (g_module == "end")			# Last command of a MODERN session
 		isempty(r) && (r = "-Vq")		# Cannot have a no-args for this case otherwise it prints help

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1727,7 +1727,7 @@ function ternary(cmd0::String="", arg1=nothing; first::Bool=true, image::Bool=fa
 		d[:par] = (MAP_GRID_PEN_PRIMARY="thinnest,gray",)
 	end
 	if (GMTver <= v"6.2.0" && (val = find_in_dict(d, CPTaliases, false)[1]) !== nothing && isa(val, GMTcpt))
-		_name = joinpath(tempdir(), "GMTjl_tmp.cpt");
+		_name = tmpdir_usr[1] * "/" * "GMTtmp_" * tmpdir_usr[2] * ".cpt"
 		gmtwrite(_name, val);	d[:C] = _name	# Workaround a bug in 6.2.0
 	end
 	(G_API[1] == C_NULL) && gmt_restart()	# Force having a valid API. We can't afford otherwise here.

--- a/src/proj_utils.jl
+++ b/src/proj_utils.jl
@@ -467,7 +467,7 @@ function geodesic_long(lonlat1::VMr, lonlat2::VMr; step=0.0, np=180, proj::Strin
 	# Compute the long way round, complementary of the shortest path between A & B. See GMT forum discussion
 	# https://forum.generic-mapping-tools.org/t/oblique-mercator-for-straight-line-between-points-as-maps-equator
 
-	_name = joinpath(tempdir(), "GMTjl_tmp.dat");	# Because of a bug in mapproject we need to save in a tmp file
+	_name = tmpdir_usr[1] * "/" * "GMTtmp_" * tmpdir_usr[2] * ".dat" 	# Due to bug in mapproject need to save in tmp file
 	
 	distAB, azA, = invgeod(lonlat1, lonlat2, proj=proj, epsg=epsg)		# Distance and azim between the end points 
 	dest1, = geod(lonlat1, azA, 39950, unit=:km, proj=proj, epsg=epsg)	# Destination of a point before the perimeter

--- a/src/pscoast.jl
+++ b/src/pscoast.jl
@@ -132,7 +132,7 @@ function coast(cmd0::String=""; clip=nothing, first=true, kwargs...)
 		cmd *= " -W0.5p"
 	end
 	(!occursin("-D",cmd)) && (cmd *= " -Da")			# Then pick automatic
-	finish = !occursin(" -M",cmd) && !occursin("-E+l", cmd) && !occursin("-E+L", cmd) ? true : false	# Otherwise the dump would be redirected to GMTjl_tmp.ps
+	finish = !occursin(" -M",cmd) && !occursin("-E+l", cmd) && !occursin("-E+L", cmd) ? true : false	# Otherwise the dump would be redirected to GMT_user.ps
 
 	# Just let D = coast(R=:PT, dump=true) work without any furthers shits (plain GMT doesn't let it)
 	(occursin(" -M",cmd) && !occursin("-E", cmd) && !occursin("-I", cmd) && !occursin("-N", cmd) && !occursin("-W", cmd) && !occursin("-A", cmd)) &&

--- a/src/psxy.jl
+++ b/src/psxy.jl
@@ -172,7 +172,7 @@ function common_plot_xyz(cmd0::String, arg1, caller::String, first::Bool, is3D::
 	(!got_Zvars) && (do_Z_fill = do_Z_outline = false)	# Because they may have wrongly been set above
 
 	if (n > 0 && GMTver <= v"6.3")						# -Z is f again. Must save data into file to make it work.
-		fname = joinpath(tempdir(), "GMTjl_temp_Z.txt")
+		fname = joinpath(tmpdir_usr[1], "GMTjl_temp_Z_" * tmpdir_usr[2] * ".txt")
 		fid = open(fname, "w")
 		for k = 1:length(args[n])  println(fid, args[n][k])  end;	close(fid)
 		cmd *= fname

--- a/src/utils_project.jl
+++ b/src/utils_project.jl
@@ -46,7 +46,7 @@ function worldrectangular(GI; proj::String="+proj=vandg +over", pm=0, latlim=:au
 	(latlim === nothing && latlims !== nothing) && (latlim = latlims)	# To accept both latlim & latlims
 	autolat = false
 	isa(latlim, StrSymb) && (autolat = true; latlim = nothing)
-	_latlim = (latlim === nothing) ? (-90,90) : (isa(latlim, Real) ? (-latlim, latlim) : latlim)
+	_latlim = (latlim === nothing) ? (-90,90) : (isa(latlim, Real) ? (-latlim, latlim) : extrema(latlim))
 	(_latlim[1] < -90 || _latlim[2] > 90) && error("Don't kidd, latlim does not have real latitude limits.")
 	!startswith(proj, "+proj=") && (proj = "+proj=" * proj)
 	!contains(proj, " +over") && (proj *= " +over")

--- a/test/test_PSs.jl
+++ b/test/test_PSs.jl
@@ -158,8 +158,8 @@ println("	PSSOLAR")
 #@assert(D[1].text[end] == "\tDuration = 10:27")
 solar(R="d", W=1, J="Q0/14c", B="a", T="dc")
 solar!(R="d", W=1, J="Q0/14c", T="dc", Vd=dbg2)
-solar(sun=(date="2016-02-09T16:00:00",), formated=true);
-t = pssolar(sun=(date="2016-02-09T16:00:00",), formated=true);
+solar(sun=(date="2016-02-09T16:00:00",), format=true);
+t = pssolar(sun=(date="2016-02-09T16:00:00",), format=true);
 
 println("	PSTERNARY")
 ternary([0.16 0.331 0.509 9.344], R="0/100/0/100/0/100", J="X6i", X=:c, B=:a, S="c0.1c");

--- a/test/test_common_opts.jl
+++ b/test/test_common_opts.jl
@@ -412,7 +412,8 @@
 	GMT.delrows!(A, [1,3]);
 
 	gmtbegin()
-	GMT.gmt_restart(false)
+		GMT.gmt_restart(false)
+	gmtend()
 	resetGMT()
 
 	skipnan([1 NaN 5])


### PR DESCRIPTION
This way the tmp names written to /tmp or TMP dirs do not clash in multi-users systems.