### PR TITLE
Do not let global transparency affect the axes too.

### DIFF
--- a/src/grdcontour.jl
+++ b/src/grdcontour.jl
@@ -71,7 +71,7 @@ function grdcontour(cmd0::String="", arg1=nothing; first=true, kwargs...)
 	d, K, O = init_module(first, kwargs...)		# Also checks if the user wants ONLY the HELP mode
 	dict_auto_add!(d)					# The ternary module may send options via another channel
 
-	cmd::String, _, opt_J::String, opt_R::String = parse_BJR(d, "", "", O, " -JX" * split(def_fig_size, '/')[1] * "/0")
+	cmd::String, opt_B, opt_J, opt_R = parse_BJR(d, "", "", O, " -JX" * split(def_fig_size, '/')[1] * "/0")
 	cmd, = parse_common_opts(d, cmd, [:UVXY :params :bo :c :e :f :h :p :t], first)
 	cmd  = parse_these_opts(cmd, d, [[:D :dump], [:F :force], [:L :range], [:Q :cut], [:S :smooth]])
 	cmd  = parse_contour_AGTW(d::Dict, cmd::String)[1]
@@ -132,7 +132,9 @@ function grdcontour(cmd0::String="", arg1=nothing; first=true, kwargs...)
 		opt_extra = "-D";		do_finish = false;	cmd = replace(cmd, opt_J => "")
 	end
 
-	_cmd = finish_PS_nested(d, ["grdcontour " * cmd])
+	_cmd = ["grdcontour " * cmd]
+	_cmd = frame_opaque(_cmd, "grdcontour", opt_B, opt_R, opt_J)		# No -t in frame
+	_cmd = finish_PS_nested(d, _cmd)
 	finish_PS_module(d, _cmd, opt_extra, K, O, do_finish, arg1, arg2, arg3)
 end
 

--- a/src/grdimage.jl
+++ b/src/grdimage.jl
@@ -104,11 +104,11 @@ function grdimage(cmd0::String="", arg1=nothing, arg2=nothing, arg3=nothing; fir
 	end
 
 	do_finish = false
+	_cmd = ["grdimage " * cmd]
+	_cmd = frame_opaque(_cmd, opt_B, opt_R, opt_J; bot=false)		# No -t in frame
 	if (!occursin("-A", cmd))			# -A means that we are requesting the image directly
-		_cmd = finish_PS_nested(d, ["grdimage " * cmd])
+		_cmd = finish_PS_nested(d, _cmd)
 		do_finish = true
-	else
-		_cmd = ["grdimage " * cmd]
 	end
 
 	_cmd = finish_PS_nested(d, _cmd)

--- a/src/grdvector.jl
+++ b/src/grdvector.jl
@@ -70,7 +70,7 @@ function grdvector(arg1, arg2; first=true, kwargs...)
 	cmd, opt_J = parse_J(d, cmd, def_J, true, O)
 	parse_theme(d)		# Must be first because some themes change def_fig_axes
 	def_fig_axes_::String = (IamModern[1]) ? "" : def_fig_axes[1]	# def_fig_axes is a global const
-	cmd = parse_B(d, cmd, (O ? "" : def_fig_axes_))[1]
+	cmd, opt_B = parse_B(d, cmd, (O ? "" : def_fig_axes_))
 
 	cmd = parse_common_opts(d, cmd, [:UVXY :f :p :t :params], first)[1]
 	!(contains(cmd, "-V")) && (cmd *= " -Ve")	# Shut up annoying warnings if -S has no units
@@ -138,7 +138,9 @@ function grdvector(arg1, arg2; first=true, kwargs...)
 	(!occursin(" -C", cmd) && !occursin(" -W", cmd) && !occursin(" -G", opt_Q)) && (cmd *= " -W0.5")	# If still nothing, set -W.
 	(opt_Q != "") && (cmd *= opt_Q)
 
-	_cmd = finish_PS_nested(d, ["grdvector " * cmd])
+	_cmd = ["grdvector " * cmd]
+	_cmd = frame_opaque(_cmd, opt_B, opt_R, opt_J)		# No -t in frame
+	_cmd = finish_PS_nested(d, _cmd)
     return finish_PS_module(d, _cmd, "", K, O, true, arg1, arg2, arg3)
 end
 

--- a/src/grdview.jl
+++ b/src/grdview.jl
@@ -75,8 +75,9 @@ function grdview(cmd0::String="", arg1=nothing; first=true, kwargs...)
 				  (mesh=("m", add_opt_fill), surface="_s", surf="_s", img=("i",arg2str), image="i", nan_alpha="_c", monochrome="_+m", waterfall=(rows="my", cols="mx", fill=add_opt_fill)))
 	cmd = add_opt(d, cmd, "W", [:W :pens :pen], (contour=("c", add_opt_pen),
 	              mesh=("m", add_opt_pen), facade=("f", add_opt_pen)) )
-	cmd = add_opt(d, cmd, "T", [:T :no_interp :tiles], (skip="_+s", skip_nan="_+s", outlines=("+o", add_opt_pen)) )
-	(!occursin(" -T", cmd)) ? cmd = parse_JZ(d, cmd, O=O, is3D=true)[1] : del_from_dict(d, [:JZ])	# Means, even if we had one, ignore silently
+	cmd = add_opt(d, cmd, "T", [:T :no_interp :tiles], (skip="_+s", skip_nan="_+s", outlines=("+o", add_opt_pen)))
+	opt_JZ = ""		# Need to have this one defined because it's need in frame_opaque() bellow.
+	(!occursin(" -T", cmd)) ? (cmd, opt_JZ = parse_JZ(d, cmd, O=O, is3D=true)[1]) : del_from_dict(d, [:JZ])	# Means, even if we had one, ignore silently
 	cmd = add_opt(d, cmd, "%", [:layout :mem_layout], nothing)
 
 	cmd, got_fname, arg1 = find_data(d, cmd0, cmd, arg1)		# Find how data was transmitted
@@ -89,7 +90,9 @@ function grdview(cmd0::String="", arg1=nothing; first=true, kwargs...)
 	cmd, arg1, arg2, arg3, arg4 = common_shade(d, cmd, arg1, arg2, arg3, arg4, "grdview")
 	cmd, arg1, arg2, arg3, arg4, arg5 = parse_G_grdview(d, [:G :drape :drapefile], cmd0, cmd, arg1, arg2, arg3, arg4, arg5)
 
-	_cmd = finish_PS_nested(d, ["grdview " * cmd])
+	_cmd = ["grdview " * cmd]
+	_cmd = frame_opaque(_cmd, opt_B, opt_R, opt_J, opt_JZ; bot=false)		# No -t in frame
+	_cmd = finish_PS_nested(d, _cmd)
 	if (length(_cmd) > 1 && cmd0 != "")		# In these cases no -R is passed so the nested calls set an unknown -R
 		for k = 2:lastindex(_cmd)  _cmd[k] = replace(_cmd[k], "-R " => "-R" * cmd0 * " ")  end
 	end

--- a/src/pshistogram.jl
+++ b/src/pshistogram.jl
@@ -122,7 +122,7 @@ function histogram(cmd0::String="", arg1=nothing; first=true, kwargs...)
 		return gmt(gmt_proggy * cmd, arg1)
 	end
 
-	cmd, _, _, opt_R ::String= parse_BJR(d, cmd, "histogram", O, " -JX14c/14c")
+	cmd, opt_B, opt_J, opt_R ::String= parse_BJR(d, cmd, "histogram", O, " -JX14c/14c")
 	cmd = parse_JZ(d, cmd)[1]
 	cmd = parse_common_opts(d, cmd, [:UVXY :JZ :c :e :f :p :t :w :params], first)[1]
 	cmd = parse_these_opts(cmd, d, [[:A :horizontal], [:F :center], [:Q :cumulative], [:S :stairs]])
@@ -239,6 +239,7 @@ function histogram(cmd0::String="", arg1=nothing; first=true, kwargs...)
 	(haskey(d, :Vd)) && (Vd_ = d[:Vd])
 
 	_cmd = [gmt_proggy * cmd]				# In any case we need this
+	(length(opt_R) > 5) && (_cmd = frame_opaque(_cmd, opt_B, opt_R, opt_J))		# No -t in frame
 	_cmd = fish_bg(d, _cmd)					# See if we have a "pre-command" (background img)
 
 	# Plot the histogram

--- a/src/psrose.jl
+++ b/src/psrose.jl
@@ -104,7 +104,9 @@ function rose(cmd0::String="", arg1=nothing; first=true, kwargs...)
 	cmd = add_opt_fill(cmd, d, [:G :fill], 'G')
 	cmd *= opt_pen(d, 'W', [:W :pen])
 
-	return finish_PS_module(d, gmt_proggy * cmd, "", K, O, true, arg1, arg2)
+	_cmd = [gmt_proggy * cmd]
+	_cmd = frame_opaque(_cmd, opt_B, opt_R, opt_J)		# No -t in frame
+	return finish_PS_module(d, _cmd, "", K, O, true, arg1, arg2)
 end
 
 # ---------------------------------------------------------------------------------------------------

--- a/src/pstext.jl
+++ b/src/pstext.jl
@@ -109,7 +109,7 @@ function text(cmd0::String="", arg1=nothing; first=true, kwargs...)
 		cmd0 = ""
 	end
 
-	cmd, _, _, opt_R = parse_BJR(d, "", "", O, " -JX" * split(def_fig_size, '/')[1] * "/0")
+	cmd, opt_B, opt_J, opt_R = parse_BJR(d, "", "", O, " -JX" * split(def_fig_size, '/')[1] * "/0")
 	cmd, = parse_common_opts(d, cmd, [:a :e :f :p :t :w :JZ :UVXY :params], first)
 	cmd  = parse_these_opts(cmd, d, [[:A :azimuths :azimuth :azim], [:M :paragraph], [:N :no_clip :noclip],
 	                                 [:Q :change_case], [:S :shade], [:T :text_box], [:Z :threeD]])
@@ -145,7 +145,9 @@ function text(cmd0::String="", arg1=nothing; first=true, kwargs...)
 		end
 	end
 
-	r = finish_PS_module(d, gmt_proggy * cmd, "", K, O, true, arg1, arg2)
+	_cmd = [gmt_proggy * cmd]
+	_cmd = frame_opaque(_cmd, gmt_proggy, opt_B, opt_R, opt_J)		# No -t in frame
+	r = finish_PS_module(d, _cmd, "", K, O, true, arg1, arg2)
 	if (isa(r, String) && startswith(r, gmt_proggy))	# It's a string when called with Vd = 2 and it may be a nested call
 		isa(arg1, GDtype) && (CTRL.pocket_call[1] = arg1)
 	end

--- a/src/pswiggle.jl
+++ b/src/pswiggle.jl
@@ -63,7 +63,7 @@ function wiggle(cmd0::String="", arg1=nothing; first=true, kwargs...)
 
 	d, K, O = init_module(first, kwargs...)		# Also checks if the user wants ONLY the HELP mode
 
-	cmd, _, _, opt_R = parse_BJR(d, "", "", O, " -JX12c/0")
+	cmd, opt_B, opt_J, opt_R = parse_BJR(d, "", "", O, " -JX12c/0")
 	cmd, = parse_common_opts(d, cmd, [:c :e :f :g :p :t :w :F :UVXY :params], first)
 	cmd  = parse_these_opts(cmd, d, [[:A :azimuth], [:C :center], [:I :fixed_azim], [:S], [:Z :ampscale :amp_scale]])
 
@@ -76,7 +76,9 @@ function wiggle(cmd0::String="", arg1=nothing; first=true, kwargs...)
 	cmd *= opt_pen(d, 'W', [:W :pen])
 	cmd = add_opt_fill(cmd, d, [:G :fill], 'G')
 
-	return finish_PS_module(d, gmt_proggy * cmd, "", K, O, true, arg1)
+	_cmd = [gmt_proggy * cmd]
+	_cmd = frame_opaque(_cmd, gmt_proggy, opt_B, opt_R, opt_J)		# No -t in frame
+	return finish_PS_module(d, _cmd, "", K, O, true, arg1)
 end
 
 # ---------------------------------------------------------------------------------------------------

--- a/src/psxy.jl
+++ b/src/psxy.jl
@@ -128,7 +128,7 @@ function common_plot_xyz(cmd0::String, arg1, caller::String, first::Bool, is3D::
 	end
 	if (is3D && isempty(opt_JZ) && length(collect(eachmatch(r"/", opt_R))) == 5)
 		cmd *= " -JZ6c"		# Default -JZ
-		CTRL.pocket_J[3] = " -JZ6c"		# Needed for eventual z-axis dir reversal.
+		opt_JZ = CTRL.pocket_J[3] = " -JZ6c"		# Needed for eventual z-axis dir reversal.
 	end
 
 	# Here we check for a direct -A of and indirect via the stairs module.
@@ -296,10 +296,11 @@ function frame_opaque(cmd::Vector{String}, oB::String, oR::String, oJ::String, o
 	oX, oY = scan_opt(cmd[1], "-X", true), scan_opt(cmd[1], "-Y", true)
 	(oX != "") && (cmd[1] = replace(cmd[1], oX => ""))	# If we have a -X and/or -Y move them to the basemap cmd
 	(oY != "") && (cmd[1] = replace(cmd[1], oY => ""))
+	p = scan_opt(cmd[1], "-p", true)
 	if bot		# Eventual grid will go UNDER the plot
-		[(IamModern[1] ? "basemap" : "psbasemap") * " " * oB * " " * oR * " " * oJ * " " * oJZ * oX * oY; cmd]
+		[(IamModern[1] ? "basemap" : "psbasemap") * " " * oB * " " * oR * " " * oJ * " " * oJZ * oX * oY * p; cmd]
 	else		# Eventual grid will go ABOVE the image
-		[cmd; (IamModern[1] ? "basemap" : "psbasemap") * " " * oB * " " * oR * " " * oJ * " " * oJZ * oX * oY]
+		[cmd; (IamModern[1] ? "basemap" : "psbasemap") * " " * oB * " " * oR * " " * oJ * " " * oJZ * oX * oY * p]
 	end
 end
 

--- a/src/psxy.jl
+++ b/src/psxy.jl
@@ -80,7 +80,7 @@ function common_plot_xyz(cmd0::String, arg1, caller::String, first::Bool, is3D::
 	end
 
 	cmd, opt_JZ = parse_JZ(d, cmd; O=O, is3D=is3D)
-	#(is3D && O && opt_JZ == "" && CTRL.pocket_J[3] == "") && (cmd *= CTRL.pocket_J[3])
+	#(is3D && O && opt_JZ == "" && CTRL.pocket_J[3] != "") && (cmd *= CTRL.pocket_J[3])
 	cmd, = parse_common_opts(d, cmd, [:a :e :f :g :p :t :w :params], first)
 	cmd, opt_l = parse_l(d, cmd)		# Parse this one (legend) aside so we can use it in classic mode
 	cmd, opt_f = parse_f(d, cmd)		# Parse this one (-f) aside so we can check against D.attrib
@@ -276,6 +276,7 @@ function common_plot_xyz(cmd0::String, arg1, caller::String, first::Bool, is3D::
 	(!IamModern[1]) && put_in_legend_bag(d, _cmd, arg1, O, opt_l)
 
 	_cmd = gmt_proggy .* _cmd				# In any case we need this
+	_cmd = frame_opaque(_cmd, opt_B, opt_R, opt_J, opt_JZ) # No -t in -B
 	_cmd = finish_PS_nested(d, _cmd)
 	_cmd = fish_bg(d, _cmd)					# See if we have a "pre-command"
 
@@ -284,6 +285,22 @@ function common_plot_xyz(cmd0::String, arg1, caller::String, first::Bool, is3D::
 	CTRL.pocket_d[1] = d					# Store d that may be not empty with members to use in other modules
 	#(occursin("-Sk", opt_S)) && gmt_restart()  # Apparently patterns & custom symbols are screwing the session
 	return r
+end
+
+# ---------------------------------------------------------------------------------------------------
+function frame_opaque(cmd::Vector{String}, oB::String, oR::String, oJ::String, oJZ::String=""; bot::Bool=true)
+	# Transparency affects the frame too, which is bad. So, if we have a transparency request we
+	# plot the frame first with a call to basemap without -t.
+	(!contains(cmd[1], " -t") || length(oB) < 3) && return cmd
+	cmd[1] = replace(cmd[1], oB => "")		# Remove the -B's that would be hit by the transparency.
+	oX, oY = scan_opt(cmd[1], "-X", true), scan_opt(cmd[1], "-Y", true)
+	(oX != "") && (cmd[1] = replace(cmd[1], oX => ""))	# If we have a -X and/or -Y move them to the basemap cmd
+	(oY != "") && (cmd[1] = replace(cmd[1], oY => ""))
+	if bot		# Eventual grid will go UNDER the plot
+		[(IamModern[1] ? "basemap" : "psbasemap") * " " * oB * " " * oR * " " * oJ * " " * oJZ * oX * oY; cmd]
+	else		# Eventual grid will go ABOVE the image
+		[cmd; (IamModern[1] ? "basemap" : "psbasemap") * " " * oB * " " * oR * " " * oJ * " " * oJZ * oX * oY]
+	end
 end
 
 # ---------------------------------------------------------------------------------------------------

--- a/test/test_common_opts.jl
+++ b/test/test_common_opts.jl
@@ -193,7 +193,7 @@
 	@test GMT.consolidate_Bframe(" -Bpx+lx -B+gwhite -Baf -BWSen -By+lx") == " -Bpx+lx -Baf -By+lx -BWSen+gwhite"
 	@test GMT.consolidate_Bframe(" -Bpx+lx -Bpy+lx -BWSrt+gwhite") == " -Bpx+lx -Bpy+lx -BWSrt+gwhite"
 	@test GMT.consolidate_Bframe(" -Bpx+lx -BWSrt+gwhite -Bpy+lx") == " -Bpx+lx -Bpy+lx -BWSrt+gwhite"
-	r = basemap(frame=(frame=(:left_full, :bot_full), fill=:lightblue), xaxis=(annot=25, ticks=5, grid=25, suffix=" Ma"), yaxis=(custom=(pos=[0 1 2 2.7 3 3.1 4 5 6 6.3], type=["a", "a", "f", "ag e", "f", "ag @~p@~", "f", "f", "f", "ag 2@~p@~"]),), Vd=2);
+	r = basemap(frame=(axes=(:left_full, :bot_full), fill=:lightblue), xaxis=(annot=25, ticks=5, grid=25, suffix=" Ma"), yaxis=(custom=(pos=[0 1 2 2.7 3 3.1 4 5 6 6.3], type=["a", "a", "f", "ag e", "f", "ag @~p@~", "f", "f", "f", "ag 2@~p@~"]),), Vd=2);
 	@test contains(r, "-Bpxa25f5g25+u\" Ma\" -BWS+glightblue")
 
 	@test GMT.arg_in_slot(Dict(:A => [1 2]), "", [:A], Matrix, [88], nothing) == (" -A", [88], [1 2])


### PR DESCRIPTION
Break the calls that have -t into a basemap plus the module call so that transparency does no screw the axes.