### PR TITLE
Let gmtset also apply its arguments immediately to the API.

### DIFF
--- a/src/GMT.jl
+++ b/src/GMT.jl
@@ -81,6 +81,7 @@ const global CONVERT_SYNTAX = Vector{Bool}(undef, 1);CONVERT_SYNTAX[1] = false	#
 const global SHOW_KWARGS = Vector{Bool}(undef, 1);SHOW_KWARGS[1] = false	# To just print the kwargs of a option call)
 const global isFranklin  = Vector{Bool}(undef, 1);isFranklin[1] = false		# Only set/unset by the Docs building scripts.
 const global noGrdCopy   = Vector{Bool}(undef, 1);noGrdCopy[1] = false		# If true, grids are sent without transpose/copy
+const global GMTCONF     = Vector{Bool}(undef, 1);GMTCONF[1] = false		# Flag if gmtset was used and must be 'unused' 
 const global FMT = ["png"]                         # The default plot format
 const global BOX_STR = [""]                        # Used in plotyy to know -R of first call
 const DEF_FIG_SIZE  = "15c/10c"                    # Default fig size for plot like programs. Approx 16/11

--- a/src/common_options.jl
+++ b/src/common_options.jl
@@ -210,9 +210,12 @@ function merge_R_and_xyzlims(d::Dict, opt_R::String)::String
 	xlim, ylim, zlim = parse_lims(d, 'x'), parse_lims(d, 'y'), parse_lims(d, 'z')
 =#
 
-	xlim::String = ((val = find_in_dict(d, [:xlim :xlims :xlimits], false)[1]) !== nothing) ? @sprintf("%.15g/%.15g", val[1], val[2]) : ""
-	ylim::String = ((val = find_in_dict(d, [:ylim :ylims :ylimits], false)[1]) !== nothing) ? @sprintf("%.15g/%.15g", val[1], val[2]) : ""
-	zlim::String = ((val = find_in_dict(d, [:zlim :zlims :zlimits], false)[1]) !== nothing) ? @sprintf("%.15g/%.15g", val[1], val[2]) : ""
+	xlim::String = ((val = find_in_dict(d, [:xlim :xlims :xlimits], false)[1]) !== nothing) ?
+	                @sprintf("%.15g/%.15g", val[1], val[2]) : ""
+	ylim::String = ((val = find_in_dict(d, [:ylim :ylims :ylimits], false)[1]) !== nothing) ?
+	                @sprintf("%.15g/%.15g", val[1], val[2]) : ""
+	zlim::String = ((val = find_in_dict(d, [:zlim :zlims :zlimits], false)[1]) !== nothing) ?
+	                @sprintf("%.15g/%.15g", val[1], val[2]) : ""
 	(xlim == "" && ylim == "" && zlim == "") && return opt_R
 	function clear_xyzlims(d::Dict, xlim, ylim, zlim)
 		# When calling this fun, if they exist they were used too so must remove them
@@ -3941,12 +3944,13 @@ function showfig(d::Dict, fname_ps::String, fname_ext::String, opt_T::String, K:
 		out = (fname != "") ? mv(fname_ps, fname, force=true) : fname_ps
 	end
 
+	retPluto = false					# To know if we are in Plut
 	if (haskey(d, :show) && d[:show] != 0)
 		if (isdefined(Main, :IJulia) && Main.IJulia.inited) #|| isdefined(Main, :VSCodeServer)		# From Jupyter?
 			#https://stackoverflow.com/questions/70620607/how-can-i-programmatically-check-that-i-am-running-code-in-a-notebook-in-julia
 			(fname == "") ? display("image/png", read(out)) : @warn("In Jupyter you can only visualize png files. File $fname was saved in disk though.")
 		elseif isdefined(Main, :PlutoRunner) && Main.PlutoRunner isa Module
-			return WrapperPluto(out)	# This return must make it all way down to base so that Plut displays it
+			retPluto = true
 		elseif (!isFranklin[1])			# !isFranklin is true when building the docs and there we don't want displays.
 			display_file(out)
 		end
@@ -3955,7 +3959,7 @@ function showfig(d::Dict, fname_ps::String, fname_ext::String, opt_T::String, K:
 	CTRL.limits .= 0.0;		CTRL.figsize .= 0.0;	CTRL.proj_linear[1] = true;		# Reset these for safety
 	CTRL.pocket_J[1], CTRL.pocket_J[2], CTRL.pocket_J[3], CTRL.pocket_J[4] = "", "", "", "   ";
 	CTRL.pocket_R[1] = ""
-	return nothing
+	return retPluto ? WrapperPluto(out) : nothing	# retPluto should make it all way down to base so that Plut displays it
 end
 
 function display_file(out)
@@ -3970,6 +3974,15 @@ function reset_theme()
 		theme_modern();		ThemeIsOn[1] = false
 		DEF_FIG_AXES[1] = DEF_FIG_AXES_BAK;		DEF_FIG_AXES3[1] = DEF_FIG_AXES3_BAK;
 	end
+	desconf()
+end
+function desconf(resetdef::Bool=true)
+	# Undo the gmtset() doing and delete eventual gmt.conf files in current dir.
+	!GMTCONF[1] && return nothing			# No gmtset was used in classic or outside a modern mode block	
+	resetdef && resetdefaults(G_API[1])		# Set the modern mode settings (will clear eventual gmt.conf contents)
+	isfile("gmt.conf") && rm("gmt.conf")	# If gmt.conf file is to be kept, save it at ~.gmt/gmt.conf
+	GMTCONF[1] = false
+	return nothing
 end
 
 # ---------------------------------------------------------------------------------------------------
@@ -3986,16 +3999,15 @@ end
 function helper_showfig4modern(show::String="show")::Bool
 	# If called from modern mode, do the equivalent of classic to close and show fig
 	# Use show="" in modern when only wanting to finish plot but NOT display it.
-	if (IamModern[1])
-		try
-			gmt("subplot end");		IamSubplot[1] = false
-		catch erro;		println(erro)
-		end
-		IamModern[1] = false
-		isFranklin[1] ? gmt("end") : (show == "") ? gmt("end") : gmt("end " * show)	# isFranklin = true when building the docs
-		return true
+	!IamModern[1] && return false
+	try
+		gmt("subplot end");		IamSubplot[1] = false
+	catch erro;		println(erro)
 	end
-	return false
+	IamModern[1] = false
+	isFranklin[1] ? gmt("end") : (show == "") ? gmt("end") : gmt("end " * show)	# isFranklin = true when building the docs
+	desconf(false)		# FALSE because modern mode calls do a gmt_restart() in the gmt() main function.
+	return true
 end
 
 # ---------------------------------------------------------------------------------------------------

--- a/src/gmtset.jl
+++ b/src/gmtset.jl
@@ -33,10 +33,12 @@ function gmtset(; kwargs...)
 	for k = 1:length(d)
 		(key[k] == :Vd)	&& continue
 		cmd *= " " * string(key[k]) * " " * string(d[key[k]])
+		gmtlib_setparameter(G_API[1], string(key[k]), string(d[key[k]]))
 		delete!(d, key[k])
 	end
+	GMTCONF[1] = true
 
 	cmd = "gmtset " * cmd
-	if (dbg_print_cmd(d, cmd) !== nothing)  return cmd  end
+	(dbg_print_cmd(d, cmd) !== nothing) && return cmd	# But here the gmtlib_setparameter doing cannot be undone
 	gmt(cmd)
 end

--- a/src/grdimage.jl
+++ b/src/grdimage.jl
@@ -128,7 +128,7 @@ end
 function common_insert_R!(d::Dict, O::Bool, cmd0, I_G)
 	# Set -R in 'd' under several conditions. We may need this to make -J=:guess to work
 	O && return
-	if ((val = find_in_dict(d, [:R :region :limits], false)[1]) === nothing && (isa(I_G, GItype)))
+	if ((val = find_in_dict(d, [:R :region :limits :region_llur :limits_llur :limits_diag :region_diag], false)[1]) === nothing && (isa(I_G, GItype)))
 		if (isa(I_G, GMTgrid) || !isimgsize(I_G))
 			d[:R] = @sprintf("%.15g/%.15g/%.15g/%.15g", I_G.range[1], I_G.range[2], I_G.range[3], I_G.range[4])
 		end
@@ -143,7 +143,8 @@ function common_insert_R!(d::Dict, O::Bool, cmd0, I_G)
 		else
 			d[:R] = val
 		end
-		del_from_dict(d, [:region, :limits])
+		!(isa(cmd0, String) && !isempty(cmd0) && (cmd0[1] == '@' || startswith(cmd0, "http"))) &&
+			del_from_dict(d, [:region, :limits, :region_llur, :limits_llur, :limits_diag, :region_diag])	# Dangerous remotes were not sniffed.
 	end
 end
 function isimgsize(I_G)

--- a/src/libgmt.jl
+++ b/src/libgmt.jl
@@ -390,6 +390,10 @@ function gmtlib_getparameter(API, keyword::String)
 	unsafe_string(ccall((:gmtlib_getparameter, libgmt), Ptr{UInt8}, (Cstring, Ptr{UInt8}), GMT_Get_Ctrl(API), keyword))
 end
 
+function gmt_getdefaults(API::Ptr{Cvoid}, file=C_NULL)
+	ccall((:gmt_getdefaults, libgmt), Cint, (Cstring, Ptr{UInt8}), GMT_Get_Ctrl(API), file)
+end
+
 function reset_defaults(API::Ptr{Cvoid})
 	ccall((:gmt_conf_SI, libgmt), Cvoid, (Cstring,), GMT_Get_Ctrl(API))
 end

--- a/src/themes.jl
+++ b/src/themes.jl
@@ -163,8 +163,8 @@ end
 # ---------------------------------------------------------------------------------------------------
 function theme_modern()
 	# Set the MODERN mode settings
-	swapmode(G_API[1], classic=false)			# Set GMT->current.setting.run_mode = GMT_MODERN
-	resetdefaults(G_API[1])
+	swapmode(G_API[1], classic=false)		# Set GMT->current.setting.run_mode = GMT_MODERN
+	resetdefaults(G_API[1])					# Set the modern mode settings (will clear eventual gmt.conf contents)
 	gmtlib_setparameter(G_API[1], "MAP_FRAME_PEN", "0.75")
 	gmtlib_setparameter(G_API[1], "FONT_TITLE", "auto,Times-Roman,black")
 	gmtlib_setparameter(G_API[1], "FONT_HEADING", "auto,Times-Roman,black")
@@ -174,19 +174,20 @@ function theme_modern()
 		gmtlib_setparameter(G_API[1], "MAP_ORIGIN_X", "0")	# Workarround GMT bug.
 		gmtlib_setparameter(G_API[1], "MAP_ORIGIN_Y", "0")
 	end
+	gmt_getdefaults(G_API[1])			# Read back eventual gmt.conf file whose contents we wipped out above
 	return nothing
 end
 
 # ---------------------------------------------------------------------------------------------------
 function theme_classic()
-	swapmode(G_API[1], classic=true)			# Set GMT->current.setting.run_mode = GMT_CLASSIC
+	swapmode(G_API[1], classic=true)	# Set GMT->current.setting.run_mode = GMT_CLASSIC
 	resetdefaults(G_API[1])
 end
 
 # ---------------------------------------------------------------------------------------------------
 function resetdefaults(API::Ptr{Cvoid})
 	# reset_defaults() lieves in libgmt.jl that is loaded very early in the loading stack, hence the need of this
-	reset_defaults(API)							# Set the modern mode settings
+	reset_defaults(API)					# Set the modern mode settings (will clear eventual gmt.conf contents)
 	extra_sets()
 end
 

--- a/src/utils_project.jl
+++ b/src/utils_project.jl
@@ -314,22 +314,22 @@ function worldrectgrid(; proj::StrSymb="", width=(30,20), grid=Vector{Vector{Rea
 		for m = meridians
 			_m = m;	(_m < -180) && (_m += 360.);	(_m > 180) && (_m -= 360.)	
 			an = isempty(annot_x) ? true : _m in annot_x
-			Dgrid[n+=1] = mat2ds(lonlat2xy([fill(m,length(meridian)) meridian], t_srs=_proj), attrib=Dict("merid_b" => "$m,-90", "merid_e" => "$m,90", "annot" => an ? "y" : "n"))
+			Dgrid[n+=1] = mat2ds(lonlat2xy([fill(m,length(meridian)) meridian], t_srs=_proj), attrib=Dict("merid_b" => "$m,-90", "merid_e" => "$m,90", "annot" => an ? "y" : "n", "n_meridians" => "$(length(meridians))", "n_parallels" => "$(length(parallels))"))
 		end
 		for p = parallels
-			Dgrid[n+=1] = mat2ds(lonlat2xy([parallel fill(p, length(parallel))], t_srs=_proj), attrib=Dict("para_b" => "$p,$(parallel[1])", "para_e" => "$p,$(parallel[end])"))
+			Dgrid[n+=1] = mat2ds(lonlat2xy([parallel fill(p, length(parallel))], t_srs=_proj), attrib=Dict("para_b" => "$p,$(parallel[1])", "para_e" => "$p,$(parallel[end])", "annot" => "n", "n_meridians" => "$(length(meridians))", "n_parallels" => "$(length(parallels))"))
 		end
 		!worldrect && check_gaps(Dgrid, length(meridians)+1, length(Dgrid))		# Try this only with non-worldrect
 	else					# Cartesian graticules
 		for m = meridians
-			Dgrid[n+=1] = mat2ds([fill(m,length(meridian)) meridian], attrib=Dict("merid_b" => "$m,-90", "merid_e" => "$m,90"))
+			Dgrid[n+=1] = mat2ds([fill(m,length(meridian)) meridian], attrib=Dict("merid_b" => "$m,-90", "merid_e" => "$m,90", "n_meridians" => "$(length(meridians))", "n_parallels" => "$(length(parallels))"))
 		end
 		for p = parallels
-			Dgrid[n+=1] = mat2ds([parallel fill(p, length(parallel))], attrib=Dict("para_b" => "$p,$(parallel[1])", "para_e" => "$p,$(parallel[end])"))
+			Dgrid[n+=1] = mat2ds([parallel fill(p, length(parallel))], attrib=Dict("para_b" => "$p,$(parallel[1])", "para_e" => "$p,$(parallel[end])", "n_meridians" => "$(length(meridians))", "n_parallels" => "$(length(parallels))"))
 		end
 	end
-	Dgrid[1].attrib["n_meridians"] = "$(length(meridians))"
-	Dgrid[1].attrib["n_parallels"] = "$(length(parallels))"
+	#Dgrid[1].attrib["n_meridians"] = "$(length(meridians))"
+	#Dgrid[1].attrib["n_parallels"] = "$(length(parallels))"
 	Dgrid[1].proj4 = _proj
 	set_dsBB!(Dgrid, false)
 	return Dgrid

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,7 +138,6 @@ using Dates, Printf#, Logging
 	# Remove garbage
 	println("	REMOVE GARBAGE")
 	rm("gmt.history")
-	rm("gmt.conf")
 	rm("lixo.ps")
 	rm("lixo.png")
 	rm("png.png")


### PR DESCRIPTION
At the end, when figs are produced, we now check and delete any gmt.conf file that lives in the local dir as well as reset the the default settings.