### PR TITLE
Fix bug in octahedron kwarg that made it return all zeros.

### DIFF
--- a/src/psxy.jl
+++ b/src/psxy.jl
@@ -1783,24 +1783,26 @@ end
 
 # ---------------------------------------------------------------------------------------------------
 """
-    replicant(FV, kwargs...) -> Vector{GMTdataset}
+    replicant(FV; kwargs...) -> Vector{GMTdataset}
 
 Take a Faces-Vertices dataset describing a 3D body and replicate it N number of times with the option of
 assigning different colors and scales to each copy. The end result is a single Vector{GMTdataset} with
 the replicated body.
 
-### Parameters
+### Args
 - `FV`: A Faces-Vertices dataset describing a 3D body.
-- `kwargs`:
-  - `replicate`: A NamedTuple with one or more of the following fields: `centers`, a Mx3 Matrix with the centers of the copies;
-    `zcolor`, a vector of length ``size(centers, 1)``, specifying a variable that will be used together with the `cmap`
-    option to assign a color of each copy (default is the ``1:size(centers, 1)``); `cmap`, a GMTcpt object; `scales`,
-    a scalar or a vector of ``size(centers, 1)``, specifying the scale factor of each copy.
-  - `replicate`: A Mx3 Matrix with the centers of the each copy.
-  - `replicate`: A Tuple with a Matrix and a scalar or a vector. The first element is the centers Mx3 matrix and the
-     second is the scale factor (or vector of factors).
-  - `view or perspective`: Set the view angle for the replication. The default is `217.5/30`. Surface elements
-     that are not visible from this persective are eliminated.
+
+### Kwargs
+- `replicate`: A NamedTuple with one or more of the following fields: `centers`, a Mx3 Matrix with the centers of the copies;
+  `zcolor`, a vector of length ``size(centers, 1)``, specifying a variable that will be used together with the `cmap`
+  option to assign a color of each copy (default is the ``1:size(centers, 1)``); `cmap`, a GMTcpt object; `scales`,
+  a scalar or a vector of ``size(centers, 1)``, specifying the scale factor of each copy.
+- `replicate`: A Mx3 Matrix with the centers of the each copy.
+- `replicate`: A Tuple with a Matrix and a scalar or a vector. The first element is the centers Mx3 matrix and the
+   second is the scale factor (or vector of factors).
+- `scales`: Scale the copies by this factor, or vector of scales (same length as number of copies)
+- `view or perspective`: Set the view angle for the replication. The default is `217.5/30`. Surface elements
+   that are not visible from this persective are eliminated.
 
 ### Returns
 A Vector{GMTdataset} with the replicated body. Normally, a triangulated surface.

--- a/src/solids.jl
+++ b/src/solids.jl
@@ -72,7 +72,7 @@ Create an octahedron mesh with radius `r`.
 - `radius`: the keyword `radius` is an alternative to the positional argument `r`.
 - `origin`: A tuple of three numbers defining the origin of the body. Default is `(0.0, 0.0, 0.0)`.
 """
-function octahedron(r=1.0; radius=0.0, origin=(0.0, 0.0, 0.0))::GMTfv
+function octahedron(r=1.0; radius=1.0, origin=(0.0, 0.0, 0.0))::GMTfv
 
 	_r::Float64 = (radius != 1.0) ? radius : r		# If spelled, the `radius` kwarg take precedence
 	o::Matrix{Float64} = [origin[1] origin[2] origin[3]]
@@ -374,7 +374,7 @@ Create an extruded 2D/3D shape.
 ### Example
 Extrude the Swisserland
 ```julia
-	Dsw = coast(M=true, DCW=(country=:CH, file=:ODS));	# Get the Swiss border
+	Dsw = coast(dump=true, DCW=(country=:CH, file=:ODS));	# Get the Swiss border
 	FV = extrude(Dsw, 0.2)
 	viz(FV)
 ```
@@ -603,9 +603,9 @@ This function is a modified version on the `revolvecurve` function from the `Com
 
 ### Example
 ```julia
-    ns=15; x=linspace(0,2*pi,ns).+1; y=zeros(size(x)); z=-cos.(x); curve=[x[:] y[:] z[:]];
-	FV = revolve(curve)
-	viz(FV, pen=0)
+ns=15; x=linspace(0,2*pi,ns).+1; y=zeros(size(x)); z=-cos.(x); curve=[x[:] y[:] z[:]];
+FV = revolve(curve)
+viz(FV, pen=0)
 ```
 """
 function revolve(curve; extent=360.0, ang1=0.0, ang2=360.0, dir=:positive, n=[0.0,0.0,1.0], n_steps::Int=0, closed=false, type=:quad)


### PR DESCRIPTION
Document the scales option in 'replicant'