### PR TITLE
Recover the ability of decoding cubes imported via rasters.jl (at least some).

### DIFF
--- a/src/utils_types.jl
+++ b/src/utils_types.jl
@@ -1068,6 +1068,11 @@ function rasters2grid(arg; scale::Real=1f0, offset::Real=0f0)::GMTgrid
 		endswith(names[1], "T00:00:00") && endswith(names[end], "T00:00:00") &&
 			(for k = 1:numel(names) names[k] = names[k][1:10] end)
 		names = collect(names)	# Because typeof(names) was of an indescritible exotherism!!!
+		v = datetime2unix.(DateTime.(names))	# _v was some CFTime, now we know what it is.
+		v_unit = "UnixTime"
+	else
+		v = _v
+		v_unit = ""
 	end
 
 	dic = !isempty(arg.metadata) ? arg.metadata.val : Dict()
@@ -1080,7 +1085,7 @@ function rasters2grid(arg; scale::Real=1f0, offset::Real=0f0)::GMTgrid
 	(eltype(data) == Int16) && (data = convert(Array{Float32, ndims(data)}, data))	# And what about UInt16, UInt8, etc ...?
 
 	(is_transp && Yorder == 'B') && (reverse!(data, dims=2); layout = "TRB")	# GMT expects grids to be scanline and Top->Bot
-	mat2grid(data, x=collect(arg.dims[1]), y=_y, v=_v, names=names, tit=string(arg.name), rem="Converted from a Rasters object.", is_transposed=is_transp, layout=layout, proj4=proj, wkt=wkt, epsg=epsg, z_unit=z_unit)
+	mat2grid(data, x=collect(arg.dims[1]), y=_y, v=v, names=names, tit=string(arg.name), rem="Converted from a Rasters object.", is_transposed=is_transp, layout=layout, proj4=proj, wkt=wkt, epsg=epsg, z_unit=z_unit, v_unit=v_unit)
 end
 
 # ---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Trouble was with the time in z-axis