### PR TITLE
Avoid calling `extrema(...; dims)` with empty arrays

### DIFF
--- a/src/gmt_main.jl
+++ b/src/gmt_main.jl
@@ -660,7 +660,7 @@ function get_dataset(API::Ptr{Nothing}, object::Ptr{Nothing})::GDtype
 				unsafe_copyto!(pointer(dest, DS.n_rows * (col - 1) + 1), unsafe_load(DS.data, col), DS.n_rows)
 			end
 			Darr[seg_out].data = dest
-			if (!isvector(dest))							# One-rowers do not have BBs
+			if (!isvector(dest) && !isempty(dest))					# One-rowers do not have BBs
 				bb = extrema(dest, dims=1)					# A N Tuple.
 				Darr[seg_out].bbox = collect(Float64, Iterators.flatten(bb))
 			end


### PR DESCRIPTION
There's a proposed "minor change" to Julia v1.13 that would make `extrema([], dims=2)` (and other such reductions) an error, akin to how `extrema([])` is an error when `init` is not specified.  This package was flagged as having (at least) one such usage here; it errored in [PkgEval](https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/813bcf3_vs_c3e7b1b/report.html).  See https://github.com/JuliaLang/julia/pull/55628 for more details.

This addresses that first such usage; there may be [other places](https://github.com/search?q=repo%3AGenericMappingTools%2FGMT.jl+%2F%28%3F%3Aextrema%7Cminimum%7Cmaximum%29.*dims%2F&type=code) that similarly need to change by either supplying `init` or skipping the empty case entirely.