### PR TITLE
Fix parsing error when finding an existing GMT in macos

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -12,13 +12,13 @@ function get_de_libnames()
 		libgmt = haskey(ENV, "GMT_LIBRARY") ? ENV["GMT_LIBRARY"] : string(chop(read(`gmt --show-library`, String)))
 
 		@static Sys.iswindows() ? libgdal = "gdal_w64.dll" : (
-			Sys.isapple() ? (libgdal = string(split(readlines(pipeline(`otool -L $(libgmt)`, `grep libgdal`))[1])[1])[8:end]) : (
+			Sys.isapple() ? (libgdal = string(split(readlines(pipeline(`otool -L $(libgmt)`, `grep libgdal`))[1])[1])) : (
 					Sys.isunix() ? (libgdal = string(split(readlines(pipeline(`ldd $(libgmt)`, `grep libgdal`))[1])[3])) :
 					error("Don't know how to use GDAL this package in this OS.")
 				)
 			)
 		@static Sys.iswindows() ? libproj = "proj_w64.dll" : (
-			Sys.isapple() ? (libproj = string(split(readlines(pipeline(`otool -L $(libgdal)`, `grep libproj`))[1])[1])[8:end]) : (
+			Sys.isapple() ? (libproj = string(split(readlines(pipeline(`otool -L $(libgdal)`, `grep libproj`))[1])[1])) : (
 					Sys.isunix() ? (libproj = string(split(readlines(pipeline(`ldd $(libgdal)`, `grep libproj`))[1])[3])) :
 					error("Don't know how to use PROJ4 in this OS.")
 				)


### PR DESCRIPTION
I found a fault when I set up the environment to debug external calls. See #1723.

Steps:

1. compile GMT using Xcode
2. set $GMT_LIBRARY to `/Users/zm/Desktop/git/gmt/xbuild/src/Debug/libgmt.dylib` (path of gmtlib compiled using Xcode)
3. set `ENV["SYSTEMWIDE_GMT"] = 1` in julia-repl
4. `using Pkg; Pkg.build("GMT")`

However, the build can't parse the correct path of gdal (`mebrew/opt/gdal/lib/libgdal.36.dylib`) due to the wrong index. So I remove it in this PR.
```
julia> Pkg.build("GMT")
    Building GMT → `~/.julia/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/c584158f845b3ae7ce51df9cd677bc1c5edff29a/build.log`

shell> cat ~/.julia/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/c584158f845b3ae7ce51df9cd677bc1c5edff29a/build.log
error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/otool-classic: can't open file: mebrew/opt/gdal/lib/libgdal.36.dylib (No such file or directory)
ProcessFailedException(Base.Process[Process(`otool -L mebrew/opt/gdal/lib/libgdal.36.dylib`, ProcessExited(1)), Process(`grep libproj`, ProcessExited(1))])

No GMT system wide installation found

```