### PR TITLE
Fix error in reading some shapefiles by exporting Gdal.wkbPointZM

### DIFF
--- a/src/gdal.jl
+++ b/src/gdal.jl
@@ -2649,7 +2649,7 @@ end
 		delaunay, dither, buffer, centroid, intersection, intersects, polyunion, fromWKT, fillnodata!, fillnodata,
 		concavehull, convexhull, difference, symdifference, distance, geomarea, geodesicarea, pointalongline, polygonize,
 		simplify, boundary, crosses, disjoint, equals, envelope, envelope3d, geomlength, overlaps, touches, within,
-		wkbUnknown, wkbPoint, wkbPointZ, wkbLineString, wkbLineStringZ, wkbPolygon, wkbPolygonZM, wkbMultiPoint,
+		wkbUnknown, wkbPoint, wkbPointZ, wkbPointZM, wkbLineString, wkbLineStringZ, wkbPolygon, wkbPolygonZM, wkbMultiPoint,
 		wkbMultiPointZ, wkbMultiLineString, wkbMultiPolygon, wkbGeometryCollection, wkbPoint25D, wkbLineString25D,
 		wkbPolygon25D, wkbMultiPoint25D, wkbMultiLineString25D, wkbMultiPolygon25D, wkbGeometryCollection25D
 


### PR DESCRIPTION
`wkbPointZM` is defined in `Gdal` and used within `ogr2GMTdataset`
with the expectation that it had been brought into scope of the
parent module with the `using Gdal` statement.  However,
`wkbPointZM` was not actually exported from `Gdal`, causing an
error when converting some files.

Add `wkbPointZM` to the list of exports in `Gdal` to fix this.

This was found when reading a Shapefile containing sets of
points.

Note that this PR does not contain any tests.  I don't really
understand Shapefiles (nor geospatial stuff generally) and am
not able to share the files which cause this problem, so I was
not sure how to write a test for this.  However
I am willing to help diagnose in any other way I can.

I also wonder whether other things should be exported from
`Gdal`, but this change fixes reading of isolated points which is
enough for me for now.
