### PR TITLE
kwargs protection: plotting modules

### DIFF
--- a/src/geodesy/psvelo.jl
+++ b/src/geodesy/psvelo.jl
@@ -9,14 +9,19 @@ See full GMT docs at [`velo`]($(GMTdoc)supplements/seis/velo.html)
     velo(mat2ds([0. -8 0 0 4 6 0.5; -8 5 3 3 0 0 0.5], ["4x6", "3x3"]), pen=(0.6,:red), fill_wedges=:green, outlines=true, Se="0.2/0.39/18", arrow="0.3c+p1p+e+gred", region=(-15,10,-10,10), show=1)
 ```
 """
-function velo(cmd0::String="", arg1=nothing; first=true, kwargs...)
+velo!(cmd0::String="", arg1=nothing; kw...) = velo(cmd0, arg1; first=false, kw...)
+velo(arg1; kw...) = velo("", arg1; first=true, kw...)
+velo!(arg1; kw...) = velo("", arg1; first=false, kw...)
+function velo(cmd0::String="", arg1=nothing; first=true, kw...)
+	d, K, O = init_module(first, kw...)		# Also checks if the user wants ONLY the HELP mode
+	velo(cmd0, arg1, O, K, d)
+end
+function velo(cmd0::String, arg1, O::Bool, K::Bool, d::Dict{Symbol, Any})
 
     proggy = (IamModern[]) ? "velo "  : "psvelo "
 
-	d, K, O = init_module(first, kwargs...)		# Also checks if the user wants ONLY the HELP mode
-
 	cmd, _, _, opt_R = parse_BJR(d, "", "", O, " -JX15cd/0d")
-	cmd, = parse_common_opts(d, cmd, [:UVXY :di :e :p :t :params]; first=first)
+	cmd, = parse_common_opts(d, cmd, [:UVXY :di :e :p :t :params]; first=!O)
 
 	if ((val = find_in_dict(d, [:A :arrow :arrows])[1]) !== nothing)
 		cmd = (isa(val, String)) ? cmd * " -A" * val : cmd * " -A" * vector_attrib(val) 
@@ -43,11 +48,6 @@ function velo(cmd0::String="", arg1=nothing; first=true, kwargs...)
 	((r = check_dbg_print_cmd(d, cmd)) !== nothing) && return r
 	prep_and_call_finish_PS_module(d, cmd, "", K, O, true, arg1)
 end
-
-# ---------------------------------------------------------------------------------------------------
-velo!(cmd0::String="", arg1=nothing; kw...) = velo(cmd0, arg1; first=false, kw...)
-velo(arg1; kw...) = velo("", arg1; first=true, kw...)
-velo!(arg1; kw...) = velo("", arg1; first=false, kw...)
 
 const psvelo  = velo 			# Alias
 const psvelo! = velo!			# Alias

--- a/src/gmtlogo.jl
+++ b/src/gmtlogo.jl
@@ -34,13 +34,16 @@ Parameters
 
 - Example, make a GMT Julia logo with circles of 1 cm: logo(GMTjulia=1, show=true)
 """
-function logo(cmd0::String=""; first=true, kwargs...)
-
-	d, K, O = init_module(first, kwargs...)		# Also checks if the user wants ONLY the HELP mode
+logo!(cmd0::String=""; first=false, kw...) = logo(cmd0; first=first, kw...)
+function logo(cmd0::String=""; first=true, kw...)
+	d, K, O = init_module(first, kw...)		# Also checks if the user wants ONLY the HELP mode
+	logo(cmd0, O, K, d)
+end
+function logo(cmd0::String, O::Bool, K::Bool, d::Dict{Symbol, Any})
 
 	cmd, = parse_R(d, "", O=O)
 	cmd, = parse_J(d, cmd, default=" -Jx1", map=true, O=O)
-	cmd, = parse_common_opts(d, cmd, [:UVXY :params]; first=first)
+	cmd, = parse_common_opts(d, cmd, [:UVXY :params]; first=!O)
 
 	cmd = parse_type_anchor(d, cmd, [:D :pos :position],
 	                        (map=("g", arg2str, 1), outside=("J", nothing, 1), inside=("j", nothing, 1), norm=("n", arg2str, 1), paper=("x", arg2str, 1), anchor=("", arg2str, 2), width="+w", size="+w", justify="+j", offset=("+o", arg2str)), 'g')
@@ -77,9 +80,6 @@ function logo(cmd0::String=""; first=true, kwargs...)
 		return prep_and_call_finish_PS_module(d, cmd, "", K, O, true)
 	end
 end
-
-# ---------------------------------------------------------------------------------------------------
-logo!(cmd0::String=""; first=false, kw...) = logo(cmd0; first=first, kw...)
 
 # -------------------------------------------------------------------------
 function jlogo(L::Float64=5.0)

--- a/src/pslegend.jl
+++ b/src/pslegend.jl
@@ -42,14 +42,19 @@ Parameters
 
 To see the full documentation type: ``@? legend``
 """
-function legend(cmd0::String="", arg1=nothing; first::Bool=true, kwargs...)
+legend!(cmd0::String="", arg1=nothing; kw...) = legend(cmd0, arg1; first=false, kw...)
+legend(arg1; kw...)  = legend("", arg1; first=true, kw...)
+legend!(arg1; kw...) = legend("", arg1; first=false, kw...)
+function legend(cmd0::String="", arg1=nothing; first::Bool=true, kw...)
+	d, K, O = init_module(first, kw...)		# Also checks if the user wants ONLY the HELP mode
+	legend(cmd0, arg1, O, K, d)
+end
+function legend(cmd0::String, arg1, O::Bool, K::Bool, d::Dict{Symbol, Any})
 
     gmt_proggy = (IamModern[]) ? "legend "  : "pslegend "
 
-	d, K, O = init_module(first, kwargs...)		# Also checks if the user wants ONLY the HELP mode
-
 	if (cmd0 == "" && arg1 === nothing && !IamModern[])
-		first && error("Need input data or file for legend")
+		!O && error("Need input data or file for legend")
 		# Here we have a bit of a convoluted case. This section is for the case where 'legend' is called without
 		# input data and relies on the data stored in previous commands by using the 'legend' keyword. That is,
 		# we use the keyword option 'position', 'fontsize', etc args as kwargs to 'legend'. As said, convoluted. 
@@ -79,7 +84,7 @@ function legend(cmd0::String="", arg1=nothing; first::Bool=true, kwargs...)
 	# where the default is 8 pts. This allows for the user to set options 'fontsize' or 'font' to override the defaults.
 	((fnt = get_legend_font(d, IamModern[] ? 0 : 8; modern=IamModern[])) != "") && (cmd *= " --FONT_ANNOT_PRIMARY=" * fnt)
 
-	cmd, = parse_common_opts(d, cmd, [:F :c :p :q :t :JZ :UVXY :params]; first=first)
+	cmd, = parse_common_opts(d, cmd, [:F :c :p :q :t :JZ :UVXY :params]; first=!O)
 
 	opt_D = parse_type_anchor(d, "", [:D :pos :position],
 	                         (map=("g", arg2str, 1), outside=("J", arg2str, 1), inside=("j", arg2str, 1), norm=("n", arg2str, 1), paper=("x", arg2str, 1), anchor=("", arg2str, 2), width=("+w", arg2str), justify="+j", spacing="+l", offset=("+o", arg2str)), 'j')
@@ -243,11 +248,6 @@ function mk_legend(; kwargs...)
 	any(c) && (leg = leg[.!c])		# Remove entries corresponding to bad options to not let go undefineds
 	leg
 end
-
-# ---------------------------------------------------------------------------------------------------
-legend!(cmd0::String="", arg1=nothing; kw...) = legend(cmd0, arg1; first=false, kw...)
-legend(arg1; kw...)  = legend("", arg1; first=true, kw...)
-legend!(arg1; kw...) = legend("", arg1; first=false, kw...)
 
 const pslegend  = legend			# Alias
 const pslegend! = legend!			# Alias

--- a/src/psmask.jl
+++ b/src/psmask.jl
@@ -60,14 +60,19 @@ Parameters
 
 To see the full documentation type: ``@? mask``
 """
-function mask(cmd0::String="", arg1=nothing; first=true, kwargs...)
+mask!(cmd0::String="", arg1=nothing; kw...) = mask(cmd0, arg1; first=false, kw...)
+mask(arg1; kw...)  = mask("", arg1; first=true, kw...)
+mask!(arg1; kw...) = mask("", arg1; first=false, kw...)
+function mask(cmd0::String="", arg1=nothing; first=true, kw...)
+	d, K, O = init_module(first, kw...)		# Also checks if the user wants ONLY the HELP mode
+	mask(cmd0, arg1, O, K, d)
+end
+function mask(cmd0::String, arg1, O::Bool, K::Bool, d::Dict{Symbol, Any})
 
     gmt_proggy = (IamModern[]) ? "mask "  : "psmask "
 
-	d, K, O = init_module(first, kwargs...)		# Also checks if the user wants ONLY the HELP mode
-
 	cmd, _, _, opt_R = parse_BJR(d, "", "", O, " -JX15c/15c")
-	cmd, = parse_common_opts(d, cmd, [:I :UVXY :JZ :c :e :p :r :t :w :params]; first=first)
+	cmd, = parse_common_opts(d, cmd, [:I :UVXY :JZ :c :e :p :r :t :w :params]; first=!O)
 	cmd  = parse_these_opts(cmd, d, [[:C :endclip :end_clip_path], [:D :dump], [:L :nodegrid], [:N :invert :inverse],
 	                                 [:Q :cut :cut_number], [:S :search_radius], [:T :tiles]])
 
@@ -91,11 +96,6 @@ function mask(cmd0::String="", arg1=nothing; first=true, kwargs...)
 	((r = check_dbg_print_cmd(d, cmd)) !== nothing) && return r
 	prep_and_call_finish_PS_module(d, cmd, "", K, O, true, arg1)
 end
-
-# ---------------------------------------------------------------------------------------------------
-mask!(cmd0::String="", arg1=nothing; kw...) = mask(cmd0, arg1; first=false, kw...)
-mask(arg1; kw...)  = mask("", arg1; first=true, kw...)
-mask!(arg1; kw...) = mask("", arg1; first=false, kw...)
 
 # ---------------------------------------------------------------------------------------------------
 # This method has nothing to do with psmask, but can be seen as an extension to it.

--- a/src/psrose.jl
+++ b/src/psrose.jl
@@ -72,20 +72,22 @@ Parameters
 
 To see the full documentation type: ``@? rose``
 """
-rose(cmd0::String; kwargs...)  = rose_helper(cmd0, nothing; kwargs...)
-rose(arg1; kwargs...)          = rose_helper("", arg1; kwargs...)
-rose!(cmd0::String; kwargs...) = rose_helper(cmd0, nothing; first=false, kwargs...)
-rose!(arg1; kwargs...)         = rose_helper("", arg1; first=false, kwargs...)
+rose(cmd0::String; kw...)  = rose_helper(cmd0, nothing; kw...)
+rose(arg1; kw...)          = rose_helper("", arg1; kw...)
+rose!(cmd0::String; kw...) = rose_helper(cmd0, nothing; first=false, kw...)
+rose!(arg1; kw...)         = rose_helper("", arg1; first=false, kw...)
 
 # ---------------------------------------------------------------------------------------------------
-function rose_helper(cmd0::String, arg1; first=true, kwargs...)
+function rose_helper(cmd0::String, arg1; first=true, kw...)
+	d, K, O = init_module(first, kw...)		# Also checks if the user wants ONLY the HELP mode
+	rose_helper(cmd0, arg1, O, K, d)
+end
+function rose_helper(cmd0::String, arg1, O::Bool, K::Bool, d::Dict{Symbol, Any})
 
     gmt_proggy = (IamModern[]) ? "rose "  : "psrose "
 
 	arg2 = nothing		# May be needed if GMTcpt type is sent in via C
 	N_args = (arg1 === nothing) ? 0 : 1
-
-	d, K, O = init_module(first, kwargs...)		# Also checks if the user wants ONLY the HELP mode
 
 	# If inquire, no plotting so do it and return
 	cmd = add_opt(d, "", "I", [:I :inquire])
@@ -96,7 +98,7 @@ function rose_helper(cmd0::String, arg1; first=true, kwargs...)
 	end
 
 	cmd, opt_B, opt_J, opt_R = parse_BJR(d, "", "", O, " -JX15c")
-	cmd, = parse_common_opts(d, cmd, [:UVXY :c :e :p :t :w :margin :params]; first=first)
+	cmd, = parse_common_opts(d, cmd, [:UVXY :c :e :p :t :w :margin :params]; first=!O)
 	cmd  = parse_these_opts(cmd, d, [[:D :shift], [:F :no_scale], [:L :labels], [:M :vector_params], [:N :vonmises],
 	                                 [:Q :alpha], [:S :norm :normalize], [:T :orientation], [:Z :scale]])
 	cmd = add_opt(d, cmd, "A", [:A :sector :sectors], (width="", rose="_+r"))

--- a/src/pssolar.jl
+++ b/src/pssolar.jl
@@ -39,15 +39,19 @@ Parameters
 
 To see the full documentation type: ``@? solar``
 """
-function solar(cmd0::String="", arg1=nothing; first=true, kwargs...)
+solar!(cmd0::String="", arg1=nothing; kw...) = solar(cmd0, arg1; first=false, kw...)
+function solar(cmd0::String="", arg1=nothing; first=true, kw...)
+	d, K, O = init_module(first, kw...)		# Also checks if the user wants ONLY the HELP mode
+	solar(cmd0, arg1, O, K, d)
+end
+function solar(cmd0::String, arg1, O::Bool, K::Bool, d::Dict{Symbol, Any})
 
 	gmt_proggy = (IamModern[]) ? "solar " : "pssolar "
-	d, K, O = init_module(first, kwargs...)		# Also checks if the user wants ONLY the HELP mode
 
 	def_J = (isempty(d)) ? " -JG0/0/14c" : " -JX14cd/0d"
 	(isempty(d)) && (d[:coast] = true; d[:T] = :d; d[:G] = "navy@75"; d[:show] = true)
 	cmd, _, opt_J, = parse_BJR(d, "", "", O, def_J)
-	cmd, = parse_common_opts(d, cmd, [:bo :c :h :o :p :t :UVXY :params]; first=first)
+	cmd, = parse_common_opts(d, cmd, [:bo :c :h :o :p :t :UVXY :params]; first=!O)
 	cmd  = parse_these_opts(cmd, d, [[:C :format], [:M :dump], [:N :invert]])
 
 	cmd  = add_opt_fill(cmd, d, [:G :fill], 'G')
@@ -69,7 +73,5 @@ function solar(cmd0::String="", arg1=nothing; first=true, kwargs...)
 end
 
 # ---------------------------------------------------------------------------------------------------
-solar!(cmd0::String="", arg1=nothing; kw...) = solar(cmd0, arg1; first=false, kw...)
-
 const pssolar  = solar				# Alias
 const pssolar! = solar!				# Alias

--- a/src/pswiggle.jl
+++ b/src/pswiggle.jl
@@ -65,12 +65,14 @@ const pswiggle! = wiggle!			# Alias
 
 # ---------------------------------------------------------------------------------------------------
 function wiggle_helper(cmd0::String, arg1; first=true, kw...)
+	d, K, O = init_module(first, kw...)		# Also checks if the user wants ONLY the HELP mode
+	wiggle_helper(cmd0, arg1, O, K, d)
+end
+function wiggle_helper(cmd0::String, arg1, O::Bool, K::Bool, d::Dict{Symbol, Any})
 	gmt_proggy = (IamModern[]) ? "wiggle "  : "pswiggle "
 
-	d, K, O = init_module(first, kw...)		# Also checks if the user wants ONLY the HELP mode
-
 	cmd, opt_B, opt_J, opt_R = parse_BJR(d, "", "", O, " -JX15c/0")
-	cmd, = parse_common_opts(d, cmd, [:c :e :f :g :p :t :w :F :UVXY :margin :params]; first=first)
+	cmd, = parse_common_opts(d, cmd, [:c :e :f :g :p :t :w :F :UVXY :margin :params]; first=!O)
 	cmd  = parse_these_opts(cmd, d, [[:A :azimuth], [:C :center], [:I :fixed_azim], [:S], [:Z :ampscale :amp_scale]])
 
 	# If file name sent in, read it and compute a tight -R if this was not provided

--- a/src/seis/gmtisf.jl
+++ b/src/seis/gmtisf.jl
@@ -27,9 +27,11 @@ Parameters
 
 This module can also be called via `gmtread`. _I.,e._ `gmtread("file.isf", opts...)_
 """
-function gmtisf(cmd0::String; kwargs...)::GMTdataset{Float64,2}
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function gmtisf(cmd0::String; kw...)::GMTdataset{Float64,2}
+	d = init_module(false, kw...)[1]
+	gmtisf(cmd0, d)
+end
+function gmtisf(cmd0::String, d::Dict{Symbol, Any})::GMTdataset{Float64,2}
 
 	cmd = parse_common_opts(d, "", [:R :V_params :yx])[1]
 	cmd = parse_these_opts(cmd, d, [[:F :focal], [:D :date], [:N :notime]])

--- a/src/seis/psmeca.jl
+++ b/src/seis/psmeca.jl
@@ -74,16 +74,16 @@ The same but add a Label
     psmeca(mat2ds([0.0 3.0 0.0 0 45 90 5 0 0], ["Thrust"]), aki=true, fill=:black, region=(-1,4,0,6), proj=:Merc, show=1)
 ```
 """
-meca(cmd0::String; kwargs...)  = meca_helper(cmd0, nothing; kwargs...)
-meca(arg1; kwargs...)          = meca_helper("", arg1; kwargs...)
-meca!(cmd0::String; kwargs...) = meca_helper(cmd0, nothing; first=false, kwargs...)
-meca!(arg1; kwargs...)         = meca_helper("", arg1; first=false, kwargs...)
+meca(cmd0::String; kw...)  = meca_helper(cmd0, nothing; kw...)
+meca(arg1; kw...)          = meca_helper("", arg1; kw...)
+meca!(cmd0::String; kw...) = meca_helper(cmd0, nothing; first=false, kw...)
+meca!(arg1; kw...)         = meca_helper("", arg1; first=false, kw...)
 
 # ---------------------------------------------------------------------------------------------------
-function meca_helper(cmd0::String, arg1; first=true, kwargs...)
+function meca_helper(cmd0::String, arg1; first=true, kw...)
     proggy = (IamModern[]) ? "meca "  : "psmeca "
-	d, K, O = init_module(first, kwargs...)		# Also checks if the user wants ONLY the HELP mode
-	common_mecas(cmd0, arg1, d, proggy, first, K, O)
+	d, K, O = init_module(first, kw...)		# Also checks if the user wants ONLY the HELP mode
+	common_mecas(cmd0, arg1, d, proggy, !O, K, O)
 end
 
 # ---------------------------------------------------------------------------------------------------
@@ -98,16 +98,16 @@ Plot cross-sections of focal mechanisms.
 See full GMT docs at [`pscoupe`]($(GMTdoc)coupe.html).
 Essentially the same as **meca** plus **A**. Run `gmthelp(coupe)` to see the list of options.
 """
-coupe(cmd0::String; kwargs...)  = coupe_helper(cmd0, nothing; kwargs...)
-coupe(arg1; kwargs...)          = coupe_helper("", arg1; kwargs...)
-coupe!(cmd0::String; kwargs...) = coupe_helper(cmd0, nothing; first=false, kwargs...)
-coupe!(arg1; kwargs...)         = coupe_helper("", arg1; first=false, kwargs...)
+coupe(cmd0::String; kw...)  = coupe_helper(cmd0, nothing; kw...)
+coupe(arg1; kw...)          = coupe_helper("", arg1; kw...)
+coupe!(cmd0::String; kw...) = coupe_helper(cmd0, nothing; first=false, kw...)
+coupe!(arg1; kw...)         = coupe_helper("", arg1; first=false, kw...)
 
 # ---------------------------------------------------------------------------------------------------
-function coupe_helper(cmd0::String, arg1; first=true, kwargs...)
+function coupe_helper(cmd0::String, arg1; first=true, kw...)
     proggy = (IamModern[]) ? "coupe "  : "pscoupe "
-	d, K, O = init_module(first, kwargs...)		# Also checks if the user wants ONLY the HELP mode
-	common_mecas(cmd0, arg1, d, proggy, first, K, O)
+	d, K, O = init_module(first, kw...)		# Also checks if the user wants ONLY the HELP mode
+	common_mecas(cmd0, arg1, d, proggy, !O, K, O)
 end
 
 const pscoupe  = coupe 			# Alias

--- a/src/windbarbs/windbarbs.jl
+++ b/src/windbarbs/windbarbs.jl
@@ -22,14 +22,17 @@ Plot wind barbs in either 2D or 3D, from table data or two u,v grids.
 
 ```
 """
-windbarbs(cmd0::String=""; first=true, kwargs...) = windbarbs(gmtread(cmd0, data=true); first=first, kwargs...)
-function windbarbs(arg1; first=true, kwargs...)
+windbarbs(cmd0::String=""; first=true, kw...) = windbarbs(gmtread(cmd0, data=true); first=first, kw...)
+function windbarbs(arg1; first=true, kw...)
+	d, K, O = init_module(first, kw...)		# Also checks if the user wants ONLY the HELP mode
+	windbarbs(arg1, O, K, d)
+end
+function windbarbs(arg1, O::Bool, K::Bool, d::Dict{Symbol, Any})
 
 	gmt_proggy = (IamModern[]) ? "barb " : "psbarb "
-	d, K, O = init_module(first, kwargs...)		# Also checks if the user wants ONLY the HELP mode
 
 	cmd, opt_B, opt_J, opt_R = parse_BJR(d, "", "", O)
-	cmd = parse_common_opts(d, cmd, [:UVXY :a :bi :di :e :f :h :i :p :t :yx :params]; first=first)[1]
+	cmd = parse_common_opts(d, cmd, [:UVXY :a :bi :di :e :f :h :i :p :t :yx :params]; first=!O)[1]
 	cmd = parse_these_opts(cmd, d, [[:D :offset], [:I :intens], [:N :no_clip :noclip]])
 	cmd = add_opt(d, cmd, "Q", [:Q :barbs], (len=("", arg2str, 1), length=("", arg2str, 1), angle="+a", fill=("+g", add_opt_fill), pen=("+p", add_opt_pen), just="+j", speed="+s", width="+w", uv="+z", cartesian="+z"))
 	cmd *= opt_pen(d, 'W', [:W :pen])
@@ -47,13 +50,18 @@ function windbarbs(arg1; first=true, kwargs...)
 	prep_and_call_finish_PS_module(d, _cmd, "", K, O, true, arg1, arg2)
 end
 
-function windbarbs(arg1::Union{String, GMTgrid}, arg2::Union{String, GMTgrid}; first=true, kwargs...)
-	d, cmd, arg1, arg2, arg3 = grdvector(arg1, arg2; first=first, barbs=true, kwargs...)	# arg3 is a possible CPT
+function windbarbs(arg1::Union{String, GMTgrid}, arg2::Union{String, GMTgrid}; first=true, kw...)
+	d, K, O = init_module(first, kw...)
+	windbarbs(arg1, arg2, O, K, d)
+end
+function windbarbs(arg1::Union{String, GMTgrid}, arg2::Union{String, GMTgrid}, O::Bool, K::Bool, d::Dict{Symbol, Any})
+	d[:barbs] = true
+	d, cmd, arg1, arg2, arg3 = grdvector_helper(arg1, arg2, K, O, d)	# arg3 is a possible CPT
 	cmd[1] = replace(cmd[1], "grdvector" => "grdbarb")
 	cmd[1] = add_opt(d, cmd[1], "Q", [:Q :barbs], (len=("", arg2str, 1), length=("", arg2str, 1), angle="+a", fill=("+g", add_opt_fill), pen=("+p", add_opt_pen), just="+j", justify="+j", speed="+s", width="+w"))
 	delete!(d, :barbs)			# Because if we used 'Q', 'barbs' was still in the dictionary
 	cmd[1] = parse_these_opts(cmd[1], d, [[:A :polar], [:T :signs :sign_scale], [:Z :azim :azimuth :azimuths]])
 
 	((r = check_dbg_print_cmd(d, cmd)) !== nothing) && return r
-	prep_and_call_finish_PS_module(d, cmd, "", first, !first, true, arg1, arg2, arg3)
+	prep_and_call_finish_PS_module(d, cmd, "", K, O, true, arg1, arg2, arg3)
 end


### PR DESCRIPTION
## Summary
- Split entry points from main logic in plotting module wrappers so that kwargs are converted to `Dict{Symbol,Any}` via `init_module` in thin wrappers before calling the main function
- This prevents Julia recompilation when kwargs change, reducing compilation overhead
- Affected modules: plot (fill_between, helper_hvband, ternary), pslegend, psmask, psrose, pssolar, pswiggle, gmtlogo, windbarbs, psvelo, psmeca/coupe, gmtisf

## Test plan
- [x] All `Vd=2` smoke tests pass
- [x] `test_B-GMTs.jl` passes (pre-existing failure on missing `test_ds_with_comment.dat` unrelated)
- [x] Actual execution tests pass for key functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)