### PR TITLE
kwargs protection: core GMT modules

### DIFF
--- a/src/blocks.jl
+++ b/src/blocks.jl
@@ -55,14 +55,17 @@ Parameters
 
 To see the full documentation type: ``@? blockmean``
 """
-blockmean(cmd0::String; kwargs...) = blockmean_helper(cmd0, nothing; kwargs...)
-blockmean(arg1; kwargs...)         = blockmean_helper("", arg1; kwargs...)
+blockmean(cmd0::String; kw...) = blockmean_helper(cmd0, nothing; kw...)
+blockmean(arg1; kw...)         = blockmean_helper("", arg1; kw...)
 
 # ---------------------------------------------------------------------------------------------------
-function blockmean_helper(cmd0::String, arg1; kwargs...)
-
-	d = KW(kwargs)
+function blockmean_helper(cmd0::String, arg1; kw...)
+	d = KW(kw)
 	help_show_options(d)		# Check if user wants ONLY the HELP mode
+	blockmean_helper(cmd0, arg1, d)
+end
+function blockmean_helper(cmd0::String, arg1, d::Dict{Symbol, Any})
+
 	cmd = parse_these_opts("", d, [[:E :extend :extended], [:S :statistic]])
 	if     (find_in_dict(d, [:npts :count])[1] !== nothing)  cmd = " -Sn"
 	elseif (find_in_dict(d, [:mean])[1] !== nothing)         cmd = " -Sm"
@@ -73,7 +76,7 @@ function blockmean_helper(cmd0::String, arg1; kwargs...)
 	(!occursin(" -E", cmd) && (occursin("s", opt_A) || occursin("h", opt_A) || occursin("l", opt_A))) && (opt_A *= " -E")
 	cmd *= opt_A
 
-	common_blocks(cmd0, arg1, d, cmd, "blockmean", kwargs...)
+	common_blocks(cmd0, arg1, d, cmd, "blockmean")
 end
 
 # ---------------------------------------------------------------------------------------------------
@@ -84,19 +87,22 @@ Block average (x,y,z) data tables by L1 norm.
 	
 To see the full documentation type: ``@? blockmedian``
 """
-blockmedian(cmd0::String; kwargs...) = blockmedian_helper(cmd0, nothing; kwargs...)
-blockmedian(arg1; kwargs...)         = blockmedian_helper("", arg1; kwargs...)
+blockmedian(cmd0::String; kw...) = blockmedian_helper(cmd0, nothing; kw...)
+blockmedian(arg1; kw...)         = blockmedian_helper("", arg1; kw...)
 
 # ---------------------------------------------------------------------------------------------------
-function blockmedian_helper(cmd0::String, arg1; kwargs...)
-
-	d = KW(kwargs)
+function blockmedian_helper(cmd0::String, arg1; kw...)
+	d = KW(kw)
 	help_show_options(d)		# Check if user wants ONLY the HELP mode
+	blockmedian_helper(cmd0, arg1, d)
+end
+function blockmedian_helper(cmd0::String, arg1, d::Dict{Symbol, Any})
+
 	cmd = parse_these_opts("", d, [[:E :extend :extended], [:Q :quick], [:T :quantile]])
 	opt_A = add_opt(d, "", "A", [:A :field :fields], (median="_z", scale="_s", highest="_h", lowest="_l", weight="_w", weights="_w"))
 	(!occursin(" -E", cmd) && (occursin("s", opt_A) || occursin("h", opt_A) || occursin("l", opt_A))) && (opt_A *= " -E")
 	cmd *= opt_A
-	common_blocks(cmd0, arg1, d, cmd, "blockmedian", kwargs...)
+	common_blocks(cmd0, arg1, d, cmd, "blockmedian")
 end
 
 # ---------------------------------------------------------------------------------------------------
@@ -107,23 +113,26 @@ Block average (x,y,z) data tables by mode estimation.
 	
 To see the full documentation type: ``@? blockmode``
 """
-blockmode(cmd0::String; kwargs...) = blockmode_helper(cmd0, nothing; kwargs...)
-blockmode(arg1; kwargs...)         = blockmode_helper("", arg1; kwargs...)
+blockmode(cmd0::String; kw...) = blockmode_helper(cmd0, nothing; kw...)
+blockmode(arg1; kw...)         = blockmode_helper("", arg1; kw...)
 
 # ---------------------------------------------------------------------------------------------------
-function blockmode_helper(cmd0::String, arg1; kwargs...)
+function blockmode_helper(cmd0::String, arg1; kw...)
+	d = init_module(false, kw...)[1]
+	blockmode_helper(cmd0, arg1, d)
+end
+function blockmode_helper(cmd0::String, arg1, d::Dict{Symbol, Any})
 
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
 	cmd = parse_these_opts("", d, [[:D :histogram_binning], [:E :extend :extended], [:Q :quick]])
 	opt_A = add_opt(d, "", "A", [:A :field :fields], (mode="_z", scale="_s", highest="_h", lowest="_l", weight="_w", weights="_w"))
 	(!occursin(" -E", cmd) && (occursin("s", opt_A) || occursin("h", opt_A) || occursin("l", opt_A))) && (opt_A *= " -E")
 	cmd *= opt_A
 
-	common_blocks(cmd0, arg1, d, cmd, "blockmode", kwargs...)
+	common_blocks(cmd0, arg1, d, cmd, "blockmode")
 end
 
 # ---------------------------------------------------------------------------------------------------
-function common_blocks(cmd0, arg1, d, cmd, proggy, kwargs...)
+function common_blocks(cmd0, arg1, d, cmd, proggy)
 
 	cmd = parse_these_opts(cmd, d, [[:C :center], [:W :weights]])
 	opt_G = parse_G(d, "")[1]

--- a/src/filter1d.jl
+++ b/src/filter1d.jl
@@ -42,9 +42,11 @@ To see the full documentation type: ``@? filter1d``
 filter1d(cmd0::String; kw...) = filter1d_helper(cmd0, nothing; kw...)
 filter1d(arg1; kw...)         = filter1d_helper("", arg1; kw...)
 
-function filter1d_helper(cmd0::String, arg1; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function filter1d_helper(cmd0::String, arg1; kw...)
+	d = init_module(false, kw...)[1]
+	filter1d_helper(cmd0, arg1, d)
+end
+function filter1d_helper(cmd0::String, arg1, d::Dict{Symbol, Any})
 
 	cmd, = parse_common_opts(d, "", [:V_params :b :d :e :f :g :h :i :o :yx])
 	cmd = parse_these_opts(cmd, d, [[:D :inc :increment], [:E :end :ends], [:L :gap_width],

--- a/src/fitcircle.jl
+++ b/src/fitcircle.jl
@@ -18,13 +18,16 @@ Parameters
 
 To see the full documentation type: ``@? fitcircle``
 """
-fitcircle(cmd0::String; kwargs...) = fitcircle_helper(cmd0, nothing; kwargs...)
-fitcircle(arg1; kwargs...)         = fitcircle_helper("", arg1; kwargs...)
+fitcircle(cmd0::String; kw...) = fitcircle_helper(cmd0, nothing; kw...)
+fitcircle(arg1; kw...)         = fitcircle_helper("", arg1; kw...)
 
 # ---------------------------------------------------------------------------------------------------
-function fitcircle_helper(cmd0::String, arg1; kwargs...)
+function fitcircle_helper(cmd0::String, arg1; kw...)
+	d = init_module(false, kw...)[1]
+	fitcircle_helper(cmd0, arg1, d)
+end
+function fitcircle_helper(cmd0::String, arg1, d::Dict{Symbol, Any})
 
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
 	cmd, = parse_common_opts(d, "", [:V_params :bi :di :e :f :g :h :i :o :yx])
 	cmd  = parse_these_opts(cmd, d, [[:L :norm], [:S :small_circle]])
 	((val = find_in_dict(d, [:F :coord :coordinates])[1]) !== nothing) && (cmd *= " -F" * arg2str(val)[1])

--- a/src/geodesy/earthtide.jl
+++ b/src/geodesy/earthtide.jl
@@ -10,9 +10,11 @@ See full GMT docs at [`earthtide`]($(GMTdoc)supplements/geodesy/earthtide.html)
 	imshow(G)
 ```
 """
-function earthtide(; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function earthtide(; kw...)
+	d = init_module(false, kw...)[1]
+	earthtide(d)
+end
+function earthtide(d::Dict{Symbol, Any})
 
 	cmd = "earthtide " * parse_common_opts(d, "", [:R :I :V_params :r])[1]
 	cmd = parse_opt_range(d, cmd, "T")[1]

--- a/src/gmt2kml.jl
+++ b/src/gmt2kml.jl
@@ -67,13 +67,15 @@ Parameters
 
 To see the full documentation type: ``@? gmt2kml``
 """
-gmt2kml(cmd0::String; kwargs...) = gmt2kml_helper(cmd0, nothing; kwargs...)
-gmt2kml(arg1; kwargs...)         = gmt2kml_helper("", arg1; kwargs...)
+gmt2kml(cmd0::String; kw...) = gmt2kml_helper(cmd0, nothing; kw...)
+gmt2kml(arg1; kw...)         = gmt2kml_helper("", arg1; kw...)
 
 # ---------------------------------------------------------------------------------------------------
-function gmt2kml_helper(cmd0::String, arg1; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function gmt2kml_helper(cmd0::String, arg1; kw...)
+	d = init_module(false, kw...)[1]
+	gmt2kml_helper(cmd0, arg1, d)
+end
+function gmt2kml_helper(cmd0::String, arg1, d::Dict{Symbol, Any})
 
 	cmd, = parse_common_opts(d, "", [:R :V_params :bi :di :e :f :h :i :yx])
 	cmd  = parse_these_opts(cmd, d, [[:A :altitude_mode], [:D :descript], [:E :extrude], [:F :feature_type], [:G :fill],

--- a/src/gmtconnect.jl
+++ b/src/gmtconnect.jl
@@ -26,9 +26,12 @@ Parameters
 
 To see the full documentation type: ``@? gmtconnect``
 """
-function gmtconnect(cmd0::String="", arg1=nothing, arg2=nothing; kwargs...)
+function gmtconnect(cmd0::String="", arg1=nothing, arg2=nothing; kw...)
+	d = init_module(false, kw...)[1]
+	gmtconnect(cmd0, arg1, d)
+end
+function gmtconnect(cmd0::String, arg1, d::Dict{Symbol, Any})
 
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
 	cmd, = parse_common_opts(d, "", [:V_params :b :d :e :f :g :h :i :o :yx])
 	cmd  = parse_these_opts(cmd, d, [[:C :closed], [:D :dump], [:L :links :linkfile], [:Q :list :listfile], [:T :tolerance]])
 

--- a/src/gmtregress.jl
+++ b/src/gmtregress.jl
@@ -47,9 +47,12 @@ Parameters
 - $(opt_w)
 - $(opt_swap_xy)
 """
-function regress(cmd0::String="", arg1=nothing; kwargs...)
+function regress(cmd0::String="", arg1=nothing; kw...)
+	d = init_module(false, kw...)[1]
+	regress(cmd0, arg1, d)
+end
+function regress(cmd0::String, arg1, d::Dict{Symbol, Any})
 
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
 	cmd, = parse_common_opts(d, "", [:V_params :b :d :e :g :h :i :o :w :yx])
     cmd  = parse_these_opts(cmd, d, [[:A :all_slopes], [:C :ci :cl :confidence_level], [:E :regression_type], [:N :norm],
                                      [:F :column_combination], [:S :restrict], [:T :equi_space], [:W :weights :weighted]])

--- a/src/gmtselect.jl
+++ b/src/gmtselect.jl
@@ -60,9 +60,11 @@ Parameters
 - $(opt_w)
 - $(opt_swap_xy)
 """
-function gmtselect(cmd0::String="", arg1=nothing, arg2=nothing, arg3=nothing, arg4=nothing; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function gmtselect(cmd0::String="", arg1=nothing, arg2=nothing, arg3=nothing, arg4=nothing; kw...)
+	d = init_module(false, kw...)[1]
+	gmtselect(cmd0, arg1, arg2, arg3, arg4, d)
+end
+function gmtselect(cmd0::String, arg1, arg2, arg3, arg4, d::Dict{Symbol, Any})
 
 	cmd::String = parse_common_opts(d, "", [:R :V_params :b :d :e :f :g :h :i :o :w :yx])[1]
 	cmd = parse_these_opts(cmd, d, [[:A :area], [:D :res :resolution], [:E :boundary],

--- a/src/gmtset.jl
+++ b/src/gmtset.jl
@@ -21,9 +21,11 @@ Parameters
 
     gmtset(FONT_ANNOT_PRIMARY="12p,Helvetica", MAP_GRID_CROSS_SIZE_PRIMARY=0.25)
 """
-function gmtset(; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function gmtset(; kw...)
+	d = init_module(false, kw...)[1]
+	gmtset(d)
+end
+function gmtset(d::Dict{Symbol, Any})
 
 	cmd = parse_V(d, "")
 	cmd = add_opt(d, cmd, "D", [:D :units])

--- a/src/gmtsimplify.jl
+++ b/src/gmtsimplify.jl
@@ -25,13 +25,15 @@ Parameters
 - $(opt_o)
 - $(opt_swap_xy)
 """
-gmtsimplify(cmd0::String; kwargs...) = gmtsimplify_helper(cmd0, nothing; kwargs...)
-gmtsimplify(arg1; kwargs...)         = gmtsimplify_helper("", arg1; kwargs...)
+gmtsimplify(cmd0::String; kw...) = gmtsimplify_helper(cmd0, nothing; kw...)
+gmtsimplify(arg1; kw...)         = gmtsimplify_helper("", arg1; kw...)
 
 # ---------------------------------------------------------------------------------------------------
-function gmtsimplify_helper(cmd0::String, arg1; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function gmtsimplify_helper(cmd0::String, arg1; kw...)
+	d = init_module(false, kw...)[1]
+	gmtsimplify_helper(cmd0, arg1, d)
+end
+function gmtsimplify_helper(cmd0::String, arg1, d::Dict{Symbol, Any})
 
 	cmd, = parse_common_opts(d, "", [:V_params :b :d :e :f :g :h :i :o :yx])
 	cmd  = add_opt(d, cmd, "T", [:T :tol :tolerance])

--- a/src/gmtvector.jl
+++ b/src/gmtvector.jl
@@ -29,10 +29,13 @@ Parameters
     Specify the vector transformation of interest.
 
 """
-function gmtvector(cmd0::String="", arg1=nothing; kwargs...)
+function gmtvector(cmd0::String="", arg1=nothing; kw...)
+	(cmd0 == "" && arg1 === nothing && length(kw) == 0) && return gmt("gmtvector")
+	d = init_module(false, kw...)[1]
+	gmtvector(cmd0, arg1, d)
+end
+function gmtvector(cmd0::String, arg1, d::Dict{Symbol, Any})
 
-	(cmd0 == "" && arg1 === nothing && length(kwargs) == 0) && return gmt("gmtvector")
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
 	cmd, = parse_common_opts(d, "", [:V_params :b :d :e :f :g :h :i :o :yx])
 	cmd  = parse_these_opts(cmd, d, [[:A :primary_vec], [:C :cartesian], [:E :geod2geoc], [:N :normalize],
 	                                 [:S :secondary_vec], [:T :transform]])

--- a/src/gmtwhich.jl
+++ b/src/gmtwhich.jl
@@ -24,9 +24,11 @@ Parameters
 	found in your local data or cache dirs.
 - $(opt_V)
 """
-function gmtwhich(cmd0::String; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function gmtwhich(cmd0::String; kw...)
+	d = init_module(false, kw...)[1]
+	gmtwhich(cmd0, d)
+end
+function gmtwhich(cmd0::String, d::Dict{Symbol, Any})
 
 	cmd = parse_V_params(d, "")
     cmd = parse_these_opts(cmd, d, [[:A :readable], [:C :confirm], [:D :report_dir], [:G :download]])

--- a/src/kml2gmt.jl
+++ b/src/kml2gmt.jl
@@ -23,9 +23,11 @@ Parameters
 
 To see the full documentation type: ``@? kml2gmt``
 """
-function kml2gmt(cmd0::String="", arg1=nothing; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function kml2gmt(cmd0::String="", arg1=nothing; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
+	kml2gmt(cmd0, arg1, d)
+end
+function kml2gmt(cmd0::String, arg1, d::Dict{Symbol, Any})
 	cmd, = parse_common_opts(d, "", [:V_params :bo :do :yx])
 	cmd  = parse_these_opts(cmd, d, [[:F :feature_type :select], [:Z :altitudes], [:E :extended]])
 	common_grd(d, cmd0, cmd, "kml2gmt ", arg1)		# Finish build cmd and run it

--- a/src/mapproject.jl
+++ b/src/mapproject.jl
@@ -70,9 +70,12 @@ Parameters
 
 To see the full documentation type: ``@? mapproject``
 """
-function mapproject(cmd0::String="", arg1=nothing, arg2=nothing; kwargs...)
+function mapproject(cmd0::String="", arg1=nothing, arg2=nothing; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
+	mapproject(cmd0, arg1, arg2, d)
+end
+function mapproject(cmd0::String, arg1, arg2, d::Dict{Symbol, Any})
 
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
 	cmd, = parse_common_opts(d, "", [:R :V_params :b :d :e :f :g :h :i :j :o :p :s :yx])
 	cmd  = parse_these_opts(cmd, d, [[:C :center], [:E :geod2ecef :ecef], [:I :inverse], [:S :supress],
 	                                 [:T :datum :change_datum], [:W :mapsize :map_size], [:Z :traveltime :travel_times]])

--- a/src/movie.jl
+++ b/src/movie.jl
@@ -102,9 +102,11 @@ Parameters
 - $(opt_V)
 - $(opt_x)
 """
-function movie(main; pre=nothing, post=nothing, kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function movie(main; pre=nothing, post=nothing, kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
+	movie(main, pre, post, d)
+end
+function movie(main, pre, post, d::Dict{Symbol, Any})
 
 	(!isa(main, Function) && !isa(main, String)) && error("A main script is mandatory")
 	((mainName = jl_sc_2_shell_sc(main, "main_script")) === nothing) && error("Main script has nothing useful")

--- a/src/project.jl
+++ b/src/project.jl
@@ -63,9 +63,11 @@ Parameters
 
 To see the full documentation type: ``@? project``
 """
-function project(cmd0::String="", arg1=nothing; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function project(cmd0::String="", arg1=nothing; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
+	project(cmd0, arg1, d)
+end
+function project(cmd0::String, arg1, d::Dict{Symbol, Any})
 	cmd, = parse_common_opts(d, "", [:V_params :b :d :e :f :g :h :i :o :s :yx])
 	cmd  = parse_these_opts(cmd, d, [[:A :azim], [:C :origin :start_point], [:E :endpoint :end_pt],
                                      [:F :outvars :out_flags], [:G :step :generate], [:L :length], [:N :flat_earth], [:Q :km], [:S :sort], [:T :pole], [:W :width], [:Z :ellipse]])


### PR DESCRIPTION
## Summary
- Split entry points from main logic in core module wrappers so that kwargs are converted to `Dict{Symbol,Any}` via `init_module` in thin wrappers before calling the main function
- Affected modules: blocks (blockmean/blockmedian/blockmode), filter1d, fitcircle, gmt2kml, gmtconnect, gmtregress, gmtselect, gmtset, gmtsimplify, gmtvector, gmtwhich, earthtide, kml2gmt, movie, project, mapproject

## Test plan
- [x] All `Vd=2` smoke tests pass
- [x] `test_B-GMTs.jl` passes
- [x] `test_P_a_T.jl` passes (project, mapproject)
- [x] Actual execution tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)