### PR TITLE
kwargs protection: grid processing modules

### DIFF
--- a/src/grdblend.jl
+++ b/src/grdblend.jl
@@ -39,9 +39,12 @@ Parameters
 - $(opt_n)
 - $(opt_r)
 """
-function grdblend(cmd0::String="", arg1=nothing, arg2=nothing; kwargs...)
+function grdblend(cmd0::String="", arg1=nothing, arg2=nothing; kw...)
+	d = init_module(false, kw...)[1]
+	grdblend(cmd0, arg1, arg2, d)
+end
+function grdblend(cmd0::String, arg1, arg2, d::Dict{Symbol, Any})
 
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
 	cmd, = parse_common_opts(d, "", [:G :I :R :V_params :f :n :r])
 	cmd  = parse_these_opts(cmd, d, [[:C :clobber], [:N :nodata], [:Q :headless], [:W :no_blend], [:Z :scale]])
 

--- a/src/grdconvert.jl
+++ b/src/grdconvert.jl
@@ -3,8 +3,11 @@
 
 """
 # ---------------------------------------------------------------------------------------------------
-function grdconvert(cmd0::AbstractString; kwargs...)::Union{Nothing, GMTgrid, String}
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function grdconvert(cmd0::AbstractString; kw...)::Union{Nothing, GMTgrid, String}
+	d = init_module(false, kw...)[1]
+	grdconvert(cmd0, d)
+end
+function grdconvert(cmd0::AbstractString, d::Dict{Symbol, Any})::Union{Nothing, GMTgrid, String}
 	cmd::String, opt_R::String = parse_R(d, "")
     cmd, = parse_common_opts(d, cmd, [:G :V_params :f])
 	cmd = parse_these_opts(cmd, d, [[:C :cmdhist], [:N :no_header], [:Z :scale]])

--- a/src/grdedit.jl
+++ b/src/grdedit.jl
@@ -48,15 +48,18 @@ Parameters
 - $(_opt_f)
 - $(opt_swap_xy)
 """
-grdedit(cmd0::String; kwargs...) = grdedit_helper(cmd0, nothing; kwargs...)
-grdedit(arg1; kwargs...)         = grdedit_helper("", arg1; kwargs...)
+grdedit(cmd0::String; kw...) = grdedit_helper(cmd0, nothing; kw...)
+grdedit(arg1; kw...)         = grdedit_helper("", arg1; kw...)
 
 # ---------------------------------------------------------------------------------------------------
-function grdedit_helper(cmd0::String, arg1; kwargs...)
+function grdedit_helper(cmd0::String, arg1; kw...)
+	(isa(arg1, GMTgrid) && length(kw) == 0) && (arg1.range[5:6] .= extrema(arg1); return arg1)  # Update the z_min|max
+	d = init_module(false, kw...)[1]
+	grdedit_helper(cmd0, arg1, d)
+end
+function grdedit_helper(cmd0::String, arg1, d::Dict{Symbol, Any})
 
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
 	arg2 = nothing
-	(isa(arg1, GMTgrid) && length(kwargs) == 0) && (arg1.range[5:6] .= extrema(arg1); return arg1)  # Update the z_min|max
 
 	cmd, = parse_common_opts(d, "", [:G :R :V_params :bi :di :e :f :w :yx])
 	cmd = parse_J(d, cmd, default=" ")[1]       # No default J here.

--- a/src/grdfft.jl
+++ b/src/grdfft.jl
@@ -45,10 +45,12 @@ Parameters
 - $(opt_V)
 - $(_opt_f)
 """
-function grdfft(cmd0::String="", arg1=nothing, arg2=nothing; kwargs...)
-
-	(cmd0 == "" && arg1 === nothing && arg2 === nothing && length(kwargs) == 0) && return gmt("grdfft")
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function grdfft(cmd0::String="", arg1=nothing, arg2=nothing; kw...)
+	(cmd0 == "" && arg1 === nothing && arg2 === nothing && length(kw) == 0) && return gmt("grdfft")
+	d = init_module(false, kw...)[1]
+	grdfft(cmd0, arg1, arg2, d)
+end
+function grdfft(cmd0::String, arg1, arg2, d::Dict{Symbol, Any})
 
 	cmd, = parse_common_opts(d, "", [:G :V_params :f])
 	is_geog = contains(cmd, " -fg")

--- a/src/grdfill.jl
+++ b/src/grdfill.jl
@@ -28,13 +28,16 @@ Parameters
 - $(opt_V)
 - $(_opt_f)
 """
-grdfill(cmd0::String; kwargs...) = grdfill_helper(cmd0, nothing; kwargs...)
-grdfill(arg1; kwargs...)         = grdfill_helper("", arg1; kwargs...)
+grdfill(cmd0::String; kw...) = grdfill_helper(cmd0, nothing; kw...)
+grdfill(arg1; kw...)         = grdfill_helper("", arg1; kw...)
 
 # ---------------------------------------------------------------------------------------------------
-function grdfill_helper(cmd0::String, arg1; kwargs...)
+function grdfill_helper(cmd0::String, arg1; kw...)
+	d = init_module(false, kw...)[1]
+	grdfill_helper(cmd0, arg1, d)
+end
+function grdfill_helper(cmd0::String, arg1, d::Dict{Symbol, Any})
 
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
 	cmd, = parse_common_opts(d, "", [:G :R :V_params :f])
 	cmd  = parse_these_opts(cmd, d, [[:A :mode :algo], [:L :list], [:N :nodata :hole]])
 

--- a/src/grdgradient.jl
+++ b/src/grdgradient.jl
@@ -38,13 +38,13 @@ Parameters
 
 To see the full documentation type: ``@? grdgradient``
 """
-function grdgradient(cmd0::String; kwargs...)
-	d, cmd = grdgrad_helper(;kwargs...)
+function grdgradient(cmd0::String; kw...)
+	d, cmd = grdgrad_helper(;kw...)
 	common_grd(d, cmd0, cmd, "grdgradient ", nothing)		# Finish build cmd and run it
 end
 
-function grdgradient(arg1; kwargs...)
-	d, cmd = grdgrad_helper(;kwargs...)
+function grdgradient(arg1; kw...)
+	d, cmd = grdgrad_helper(;kw...)
 	common_grd(d, "", cmd, "grdgradient ", arg1)		# Finish build cmd and run it
 end
 

--- a/src/grdhisteq.jl
+++ b/src/grdhisteq.jl
@@ -30,14 +30,14 @@ Parameters
 
 To see the full documentation type: ``@? grdhisteq``
 """
-function grdhisteq(cmd0::String; kwargs...)
-	d, cmd = grdhisteq_helper(; kwargs...)
+function grdhisteq(cmd0::String; kw...)
+	d, cmd = grdhisteq_helper(; kw...)
 	common_grd(d, cmd0, cmd, "grdhisteq ")			# Finish build cmd and run it
 end
 
 # ---------------------------------------------------------------------------------------------------
-function grdhisteq(arg1; kwargs...)
-	d, cmd = grdhisteq_helper(; kwargs...)
+function grdhisteq(arg1; kw...)
+	d, cmd = grdhisteq_helper(; kw...)
 	common_grd(d, "", cmd, "grdhisteq ", arg1)		# Finish build cmd and run it
 end
 

--- a/src/grdinterpolate.jl
+++ b/src/grdinterpolate.jl
@@ -59,13 +59,16 @@ or use `allcols=true`.
 
 To see the full documentation type: ``@? grdinterpolate``
 """
-grdinterpolate(cmd0::String; kwargs...) = grdinterp_helper(cmd0, nothing; kwargs...)
-grdinterpolate(arg1; kwargs...)         = grdinterp_helper("", arg1; kwargs...)
+grdinterpolate(cmd0::String; kw...) = grdinterp_helper(cmd0, nothing; kw...)
+grdinterpolate(arg1; kw...)         = grdinterp_helper("", arg1; kw...)
 
-function grdinterp_helper(cmd0::String, arg1; allcols::Bool=false, gdal=false, kwargs...)
+function grdinterp_helper(cmd0::String, arg1; allcols::Bool=false, gdal=false, kw...)
+	d = init_module(false, kw...)[1]
+	grdinterp_helper(cmd0, arg1, allcols, gdal, d)
+end
+function grdinterp_helper(cmd0::String, arg1, allcols::Bool, gdal, d::Dict{Symbol, Any})
 
 	arg2 = nothing
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
 
 	cmd = parse_common_opts(d, "", [:R :V_params :bi :bo :di :e :f :g :h :i :n :o :q :s :yx])[1]
 	cmd = parse_these_opts(cmd, d, [[:G :outfile :outgrid], [:Z :levels]])

--- a/src/grdpaste.jl
+++ b/src/grdpaste.jl
@@ -18,11 +18,13 @@ Parameters
 
 To see the full documentation type: ``@? grdpaste``
 """
-function grdpaste(G1::GItype, G2::GItype; kwargs...)
-
+function grdpaste(G1::GItype, G2::GItype; kw...)
 	(GMTver < v"6.5.0") && (@warn("This module doesn't work for the installed GMT version. Run 'upGMT(true)' to update it."); return nothing)
 	(G1.layout != "" && G1.layout[2] == 'R') && error("Pasting row oriented grids (such those produced by GDAL) is not implemented.")
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+	d = init_module(false, kw...)[1]
+	grdpaste(G1, G2, d)
+end
+function grdpaste(G1::GItype, G2::GItype, d::Dict{Symbol, Any})
 	cmd, = parse_common_opts(d, "", [:G :V_params :f])
 	cmd *= " -S"
 	side::GMTdataset = common_grd(d, "grdpaste " * cmd, G1, G2)		# Finish build cmd and run it
@@ -47,13 +49,16 @@ function grdpaste(G1::GItype, G2::GItype; kwargs...)
 end
 
 # ---------------------------------------------------------------------------------------------------
-grdpaste(G1::String, G2::GItype; kwargs...) = grdpaste(gmtread(G1), G2; kwargs...)
-grdpaste(G1::GItype, G2::String; kwargs...) = grdpaste(G1, gmtread(G2); kwargs...)
+grdpaste(G1::String, G2::GItype; kw...) = grdpaste(gmtread(G1), G2; kw...)
+grdpaste(G1::GItype, G2::String; kw...) = grdpaste(G1, gmtread(G2); kw...)
 
 # ---------------------------------------------------------------------------------------------------
-function grdpaste(G1::String, G2::String; kwargs...)
+function grdpaste(G1::String, G2::String; kw...)
 	# This method lets pass two file names and either return the pasted grid or save in on disk.
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+	d = init_module(false, kw...)[1]
+	grdpaste(G1, G2, d)
+end
+function grdpaste(G1::String, G2::String, d::Dict{Symbol, Any})
 	cmd, = parse_common_opts(d, "", [:G :V_params :f])
 	cmd != "" && (cmd = " " * cmd)
 	gmt("grdpaste " * G1 * " " * G2 * cmd)

--- a/src/grdvolume.jl
+++ b/src/grdvolume.jl
@@ -28,9 +28,12 @@ Parameters
 
 To see the full documentation type: ``@? grdvolume``
 """
-function grdvolume(cmd0::String="", arg1=nothing; kwargs...)
+function grdvolume(cmd0::String="", arg1=nothing; kw...)
+	d = init_module(false, kw...)[1]
+	grdvolume(cmd0, arg1, d)
+end
+function grdvolume(cmd0::String, arg1, d::Dict{Symbol, Any})
 
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
 	cmd, = parse_common_opts(d, "", [:R :V_params :f :o])
 	cmd  = parse_these_opts(cmd, d, [[:C :cont :contour], [:D :diff :difference], [:L :base_level :baselevel], [:S :unit], [:T :find_max :findmax], [:Z :scale]])
 	common_grd(d, cmd0, cmd, "grdvolume ", arg1)		# Finish build cmd and run it

--- a/src/greenspline.jl
+++ b/src/greenspline.jl
@@ -73,13 +73,16 @@ Parameters
 
 To see the full documentation type: ``@? greenspline``
 """
-greenspline(cmd0::String; kwargs...) = greenspline_helper(cmd0, nothing; kwargs...)
-greenspline(arg1; kwargs...)         = greenspline_helper("", arg1; kwargs...)
+greenspline(cmd0::String; kw...) = greenspline_helper(cmd0, nothing; kw...)
+greenspline(arg1; kw...)         = greenspline_helper("", arg1; kw...)
 
 # ---------------------------------------------------------------------------------------------------
-function greenspline_helper(cmd0::String, arg1; kwargs...)
+function greenspline_helper(cmd0::String, arg1; kw...)
+	d = init_module(false, kw...)[1]
+	greenspline_helper(cmd0, arg1, d)
+end
+function greenspline_helper(cmd0::String, arg1, d::Dict{Symbol, Any})
 
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
 	arg2 = nothing;     arg3 = nothing
 
 	cmd, = parse_common_opts(d, "", [:I :R :V_params :bi :d :e :f :h :i :o :r :x :w :yx])

--- a/src/nearneighbor.jl
+++ b/src/nearneighbor.jl
@@ -43,15 +43,17 @@ Parameters
 
 To see the full documentation type: ``@? nearneighbor``
 """
-nearneighbor(cmd0::String; kwargs...) = nearneighbor_helper(cmd0, nothing; kwargs...)
-nearneighbor(arg1; kwargs...)         = nearneighbor_helper("", arg1; kwargs...)
-nearneighbor(; kwargs...)             = nearneighbor_helper("", nothing; kwargs...)		# To allow nearneighbor(data=..., ...)
+nearneighbor(cmd0::String; kw...) = nearneighbor_helper(cmd0, nothing; kw...)
+nearneighbor(arg1; kw...)         = nearneighbor_helper("", arg1; kw...)
+nearneighbor(; kw...)             = nearneighbor_helper("", nothing; kw...)		# To allow nearneighbor(data=..., ...)
 
 # ---------------------------------------------------------------------------------------------------
-function nearneighbor_helper(cmd0::String, arg1; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function nearneighbor_helper(cmd0::String, arg1; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
 	d = seek_auto_RI(d, cmd0, arg1)				# If -R -I (or one of them) not set, guess.
+	nearneighbor_helper(cmd0, arg1, d)
+end
+function nearneighbor_helper(cmd0::String, arg1, d::Dict{Symbol, Any})
 	cmd, = parse_common_opts(d, "", [:G :RIr :V_params :bi :di :e :f :h :i :n :w :yx])
 	cmd  = parse_these_opts(cmd, d, [[:E :empty], [:S :search_radius], [:W :weights], [:A]])
 	cmd  = add_opt(d, cmd, "N", [:N :sectors], (n="", min_sectors="+m"))

--- a/src/surface.jl
+++ b/src/surface.jl
@@ -75,10 +75,8 @@ Parameters
 
 To see the full documentation type: ``@? surface``
 """
-function surface(cmd0::String="", arg1::Union{Nothing, MatGDsGd}=nothing; kwargs...)::Union{Nothing, GMTgrid, String}
-
-	arg2 = nothing
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function surface(cmd0::String="", arg1::Union{Nothing, MatGDsGd}=nothing; kw...)::Union{Nothing, GMTgrid, String}
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
 	d = seek_auto_RI(d, cmd0, arg1)				# If -R -I (or one of them) not set, guess.
 
 	if ((val = find_in_dict(d, [:preproc :preprocess])[1]) !== nothing)
@@ -90,9 +88,13 @@ function surface(cmd0::String="", arg1::Union{Nothing, MatGDsGd}=nothing; kwargs
 			println(string(fun, " -R",d[:R], " -I",d[:I], " -r",r))
 		else
 			arg1 = (cmd0 != "") ? fun(cmd0; R=d[:R], I=d[:I], r=r) : fun(arg1; R=d[:R], I=d[:I], r=r)
-			cmd0 = ""	# Since it may have been just consumed above 
+			cmd0 = ""	# Since it may have been just consumed above
 		end
 	end
+	surface(cmd0, arg1, d)
+end
+function surface(cmd0::String, arg1::Union{Nothing, MatGDsGd}, d::Dict{Symbol, Any})::Union{Nothing, GMTgrid, String}
+	arg2 = nothing
 
 	cmd, = parse_common_opts(d, "", [:G :RIr :V_params :a :bi :di :e :f :h :i :w :yx])
 	cmd  = parse_these_opts(cmd, d, [[:A :aspect_ratio], [:C :convergence], [:Ll :lower], [:Lu :upper], [:M :mask],

--- a/src/triangulate.jl
+++ b/src/triangulate.jl
@@ -65,13 +65,15 @@ Parameters
 
 To see the full documentation type: ``@? triangulate``
 """
-triangulate(cmd0::String; kwargs...) = triangulate_helper(cmd0, nothing; kwargs...)
-triangulate(arg1; kwargs...)         = triangulate_helper("", arg1; kwargs...)
+triangulate(cmd0::String; kw...) = triangulate_helper(cmd0, nothing; kw...)
+triangulate(arg1; kw...)         = triangulate_helper("", arg1; kw...)
 
 # ---------------------------------------------------------------------------------------------------
-function triangulate_helper(cmd0::String, arg1; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function triangulate_helper(cmd0::String, arg1; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
+	triangulate_helper(cmd0, arg1, d)
+end
+function triangulate_helper(cmd0::String, arg1, d::Dict{Symbol, Any})
 	cmd, = parse_common_opts(d, "", [:G :RIr :V_params :margin :bi :bo :di :e :f :h :i :w :yx])
 	(haskey(d, :Z) && isa(d[:Z], Bool) && !d[:Z]) && delete!(d, :Z)		# Strip Z=false from 'd' (for triplot)
 	cmd  = parse_these_opts(cmd, d, [[:A :area], [:C :slope_grid], [:D :derivatives], [:E :empty], [:L :index],

--- a/src/xyz2grd.jl
+++ b/src/xyz2grd.jl
@@ -41,18 +41,19 @@ Parameters
 
 To see the full documentation type: ``@? xyz2grd``
 """
-function xyz2grd(cmd0::String="", arg1=nothing; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
-
+function xyz2grd(cmd0::String="", arg1=nothing; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
 	_prj = ((val = find_in_dict(d, [:J :proj :projection])[1]) !== nothing) ? val : ""
 	prj::String = isa(_prj, Integer) ? epsg2proj(_prj) : _prj		# Accept also EPSGs
-	cmd, = parse_common_opts(d, "", [:G :RIr :J :V_params :bi :di :e :f :h :i :w :yx])
-	cmd  = parse_these_opts(cmd, d, [[:A :multiple_nodes], [:D :header], [:S :swap], [:Z :flags]])
 	if (cmd0 == "" && arg1 === nothing)
 		(haskey(d, :x) && haskey(d, :y) && haskey(d, :z)) && (arg1 = hcat(d[:x], d[:y], d[:z]))
 		(arg1 !== nothing) && (delete!(d, :x); delete!(d, :y); delete!(d, :z))
 	end
+	xyz2grd(cmd0, arg1, prj, d)
+end
+function xyz2grd(cmd0::String, arg1, prj::String, d::Dict{Symbol, Any})
+	cmd, = parse_common_opts(d, "", [:G :RIr :J :V_params :bi :di :e :f :h :i :w :yx])
+	cmd  = parse_these_opts(cmd, d, [[:A :multiple_nodes], [:D :header], [:S :swap], [:Z :flags]])
 	G = common_grd(d, cmd0, cmd, "xyz2grd ", arg1)		# Finish build cmd and run it
 	(prj != "") && (setproj!(G, prj))
 	if (isa(G, GMTgrid) && G.proj4 == "+xy")


### PR DESCRIPTION
## Summary
- Split entry points from main logic in grid module wrappers so that kwargs are converted to `Dict{Symbol,Any}` via `init_module` in thin wrappers before calling the main function
- Affected modules: grdblend, grdconvert, grdedit, grdfft, grdfill, grdgradient, grdhisteq, grdinterpolate, grdpaste, grdvolume, greenspline, nearneighbor, surface, triangulate, xyz2grd

## Test plan
- [x] All `Vd=2` smoke tests pass
- [x] `test_GRDs.jl` passes (pre-existing failure on missing `cube.nc` unrelated)
- [x] `test_P_a_T.jl` passes (surface, triangulate, nearneighbor, xyz2grd)
- [x] Actual execution tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)