### PR TITLE
kwargs protection: analysis, potential & MB modules

### DIFF
--- a/src/MB/mbgetdata.jl
+++ b/src/MB/mbgetdata.jl
@@ -30,10 +30,11 @@ Parameters
 - $(opt_n)
 - $(_opt_t)
 """
-function mbgetdata(cmd0::String=""; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
-
+function mbgetdata(cmd0::String=""; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
+	mbgetdata(cmd0, d)
+end
+function mbgetdata(cmd0::String, d::Dict{Symbol, Any})
 	cmd, opt_R = parse_R(d, "")
 	cmd, = parse_common_opts(d, cmd, [:UVXY :params]; first=true)
 

--- a/src/MB/mbimport.jl
+++ b/src/MB/mbimport.jl
@@ -37,10 +37,11 @@ Parameters
 - $(opt_n)
 - $(_opt_t)
 """
-function mbimport(cmd0::String=""; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
-
+function mbimport(cmd0::String=""; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
+	mbimport(cmd0, d)
+end
+function mbimport(cmd0::String, d::Dict{Symbol, Any})
 	cmd, opt_R = parse_R(d, "")
 	cmd, opt_J = parse_J(d, cmd, default=" -JX15cd/0", map=true)
 	cmd, = parse_common_opts(d, cmd, [:UVXY :params :n :t]; first=true)

--- a/src/MB/mblevitus.jl
+++ b/src/MB/mblevitus.jl
@@ -24,10 +24,11 @@ Parameters
     Makes Z axes positive down (default here is Z-up).
 - $(opt_V)
 """
-function mblevitus(cmd0::String=""; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
-
+function mblevitus(cmd0::String=""; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
+	mblevitus(cmd0, d)
+end
+function mblevitus(cmd0::String, d::Dict{Symbol, Any})
 	cmd = parse_common_opts(d, "", [:yx :V_params :o])[1]
 	cmd = add_opt(d, cmd, "L", [:L :location :R])
 	(!occursin("-L", cmd)) && (cmd *= " -L0/0")

--- a/src/MB/mbsvplist.jl
+++ b/src/MB/mbsvplist.jl
@@ -24,10 +24,11 @@ Parameters
 - $(_opt_R)
 - $(opt_V)
 """
-function mbsvplist(cmd0::String=""; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
-
+function mbsvplist(cmd0::String=""; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
+	mbsvplist(cmd0, d)
+end
+function mbsvplist(cmd0::String, d::Dict{Symbol, Any})
 	cmd = parse_common_opts(d, "", [:R :yx :V_params :o])[1]
 	cmd = parse_these_opts(cmd, d, [[:C :uniquesvp], [:F :format], [:H :help], [:M :mode], [:S :ssv], [:Z :firstiszero], [:z :z_down]])
 	((val = find_in_dict(d, [:z :z_down])[1]) === nothing) && (cmd *= " -z")	# Means here default is Z-up

--- a/src/potential/gmtgravmag3d.jl
+++ b/src/potential/gmtgravmag3d.jl
@@ -47,16 +47,16 @@ Parameters
 	imshow(G)
 ```
 """
-gravmag3d(cmd0::String; kwargs...) = gravmag3d_helper(cmd0, nothing; kwargs...)
-gravmag3d(arg1; kwargs...)         = gravmag3d_helper("", arg1; kwargs...)
-gravmag3d(; kwargs...)             = gravmag3d_helper("", nothing; kwargs...)
+gravmag3d(cmd0::String; kw...) = gravmag3d_helper(cmd0, nothing; kw...)
+gravmag3d(arg1; kw...)         = gravmag3d_helper("", arg1; kw...)
+gravmag3d(; kw...)             = gravmag3d_helper("", nothing; kw...)
 
-function gravmag3d_helper(cmd0::String, arg1; kwargs...)
-	(cmd0 == "" && arg1 === nothing && length(kwargs) == 0) && return gmt("gmtgravmag3d")
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function gravmag3d_helper(cmd0::String, arg1; kw...)
+	(cmd0 == "" && arg1 === nothing && length(kw) == 0) && return gmt("gmtgravmag3d")
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
 	(cmd0 != "") && (arg1 = gmtread(cmd0, data=true))
 	if (isa(arg1, GMTfv))
-		v = mat2ds(arg1.verts) 
+		v = mat2ds(arg1.verts)
 		f = arg1.faces[1]# .- 1
 		d[:Tf] = f
 		d[:Q] = true

--- a/src/potential/gravfft.jl
+++ b/src/potential/gravfft.jl
@@ -49,10 +49,13 @@ To see the full documentation type: ``@? gravfft``
 ```
 """
 gravfft(arg1, arg2=nothing; kw...) = gravfft("", arg1, arg2; kw...)
-function gravfft(cmd0::String="", arg1=nothing, arg2=nothing; kwargs...)
+function gravfft(cmd0::String="", arg1=nothing, arg2=nothing; kw...)
+	d = init_module(false, kw...)[1]
+	gravfft(cmd0, arg1, arg2, d)
+end
+function gravfft(cmd0::String, arg1, arg2, d::Dict{Symbol, Any})
 
 	arg3 = nothing
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
 
 	cmd::String = parse_common_opts(d, "", [:G :V_params :f])[1]
 	cmd = add_opt(d, cmd, "C", [:C :tadmitt], (n="", lambda="", mean_depth="", from_top="_/t", from_below="_/b", wavelengths="_w"))

--- a/src/potential/gravprisms.jl
+++ b/src/potential/gravprisms.jl
@@ -55,13 +55,15 @@ Parameters
 
     Give name of an output grid with spatially varying, vertically-averaged prism densities created by C and H.
 """
-function gravprisms(cmd0::String="", arg1::GDtype=GMTdataset(); kwargs...)
+function gravprisms(cmd0::String="", arg1::GDtype=GMTdataset(); kw...)
+	d = init_module(false, kw...)[1]
+	gravprisms(cmd0, arg1, d)
+end
+function gravprisms(cmd0::String, arg1::GDtype, d::Dict{Symbol, Any})
 
 	Gs = Vector{GMTgrid}(undef, 5)
 	N_used = 0
 	arg2::GDtype=GMTdataset()
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
 
 	function fish_grids(d, Gs, cmd, symbs, opt, N)
 		if ((_val = find_in_dict(d, symbs)[1]) !== nothing)

--- a/src/potential/grdgravmag3d.jl
+++ b/src/potential/grdgravmag3d.jl
@@ -50,10 +50,13 @@ Parameters
 ```
 """
 grdgravmag3d(arg1, arg2=nothing; kw...) = grdgravmag3d("", arg1, arg2; kw...)
-function grdgravmag3d(cmd0::String="", arg1=nothing, arg2=nothing; kwargs...)
-	(cmd0 == "" && arg1 === nothing && arg2 === nothing && length(kwargs) == 0) && return gmt("grdgravmag3d")
+function grdgravmag3d(cmd0::String="", arg1=nothing, arg2=nothing; kw...)
+	(cmd0 == "" && arg1 === nothing && arg2 === nothing && length(kw) == 0) && return gmt("grdgravmag3d")
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
+	grdgravmag3d(cmd0, arg1, arg2, d)
+end
+function grdgravmag3d(cmd0::String, arg1, arg2, d::Dict{Symbol, Any})
 	arg3, arg4 = nothing, nothing
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
 
 	cmd::String = parse_common_opts(d, "", [:G :RIr :V_params :f :x])[1]
 	cmd = parse_these_opts(cmd, d, [[:E :thickness], [:Q :pad], [:L :z_obs :observation_level], [:S :radius]])

--- a/src/potential/grdseamount.jl
+++ b/src/potential/grdseamount.jl
@@ -3,14 +3,14 @@
 
 Create synthetic seamounts (Gaussian, parabolic, polynomial, cone or disc; circular or elliptical).
 """
-grdseamount(cmd0::String; kwargs...) = grdseamount_helper(cmd0, nothing; kwargs...)
-grdseamount(arg1; kwargs...)         = grdseamount_helper("", arg1; kwargs...)
+grdseamount(cmd0::String; kw...) = grdseamount_helper(cmd0, nothing; kw...)
+grdseamount(arg1; kw...)         = grdseamount_helper("", arg1; kw...)
 
-function grdseamount_helper(cmd0::String, arg1; kwargs...)
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function grdseamount_helper(cmd0::String, arg1; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
 	(cmd0 != "") && (arg1 = gmtread(cmd0))
 	isa(arg1, Matrix{<:Real}) && (arg1 = mat2ds(Float64.(arg1)))
-    grdseamount_helper(arg1, d)
+	grdseamount_helper(arg1, d)
 end
 
 # ---------------------------------------------------------------------------------------------------

--- a/src/spectrum1d.jl
+++ b/src/spectrum1d.jl
@@ -48,9 +48,11 @@ spectrum1d(cmd0::String; kw...) = spectrum1d_helper(cmd0, nothing; kw...)
 spectrum1d(arg1; kw...)         = spectrum1d_helper("", arg1; kw...)
 
 # ---------------------------------------------------------------------------------------------------
-function spectrum1d_helper(cmd0::String, arg1; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function spectrum1d_helper(cmd0::String, arg1; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
+	spectrum1d_helper(cmd0, arg1, d)
+end
+function spectrum1d_helper(cmd0::String, arg1, d::Dict{Symbol, Any})
 	cmd = parse_common_opts(d, "", [:V_params :b :d :e :g :h :i :yx])[1]
 	cmd = parse_these_opts(cmd, d, [[:D :sample_dist], [:L :leave_trend], [:N :name], [:S :size], [:T :multifiles], [:W :wavelength]])
 	opt_C = add_opt(d, "", "C", [:C :components :output],

--- a/src/sphdistance.jl
+++ b/src/sphdistance.jl
@@ -44,10 +44,11 @@ Parameters
 
 To see the full documentation type: ``@? sphdistance``
 """
-function sphdistance(cmd0::String="", arg1=nothing, arg2=nothing; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
-
+function sphdistance(cmd0::String="", arg1=nothing, arg2=nothing; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
+	sphdistance(cmd0, arg1, arg2, d)
+end
+function sphdistance(cmd0::String, arg1, arg2, d::Dict{Symbol, Any})
 	cmd, = parse_common_opts(d, "", [:G :RIr :V_params :b :d :e :h :i :j :yx])
 	cmd  = parse_these_opts(cmd, d, [[:C :save_mem], [:D :duplicates], [:E :quantity], [:L :dist_unit]])
 	cmd, arg1, arg2 = parse_QN_sphdst(d, [[:Q :voronoi], [:N :nodes]], cmd, arg1, arg2)

--- a/src/sphinterpolate.jl
+++ b/src/sphinterpolate.jl
@@ -37,9 +37,11 @@ Parameters
 
 To see the full documentation type: ``@? sphinterpolate``
 """
-function sphinterpolate(cmd0::String="", arg1=nothing; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function sphinterpolate(cmd0::String="", arg1=nothing; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
+	sphinterpolate(cmd0, arg1, d)
+end
+function sphinterpolate(cmd0::String, arg1, d::Dict{Symbol, Any})
 	cmd, = parse_common_opts(d, "", [:G :RIr :V_params :bi :di :e :h :i :yx])
 	cmd  = parse_these_opts(cmd, d, [[:D :skipdup :duplicates], [:Q :tension], [:T :nodetable], [:Z :scale]])
 

--- a/src/sphtriangulate.jl
+++ b/src/sphtriangulate.jl
@@ -40,9 +40,11 @@ Parameters
 
 To see the full documentation type: ``@? sphtriangulate``
 """
-function sphtriangulate(cmd0::String="", arg1=nothing; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function sphtriangulate(cmd0::String="", arg1=nothing; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
+	sphtriangulate(cmd0, arg1, d)
+end
+function sphtriangulate(cmd0::String, arg1, d::Dict{Symbol, Any})
 	cmd, = parse_common_opts(d, "", [:V_params :b :d :e :h :i :yx])
 	cmd  = parse_these_opts(cmd, d, [[:A :area], [:C :save_mem], [:D :skipdup :duplicates :skip], [:L :unit], [:N :nodes], [:Q :voronoi], [:T :arcs]])
 	common_grd(d, cmd0, cmd, "sphtriangulate ", arg1)		# Finish build cmd and run it

--- a/src/splitxyz.jl
+++ b/src/splitxyz.jl
@@ -49,13 +49,15 @@ Parameters
 
 To see the full documentation type: ``@? splitxyz``
 """
-gmtsplit(cmd0::String; kwargs...) = gmtsplit_helper(cmd0, nothing; kwargs...)
-gmtsplit(arg1; kwargs...)         = gmtsplit_helper("", arg1; kwargs...)
+gmtsplit(cmd0::String; kw...) = gmtsplit_helper(cmd0, nothing; kw...)
+gmtsplit(arg1; kw...)         = gmtsplit_helper("", arg1; kw...)
 
 # ---------------------------------------------------------------------------------------------------
-function gmtsplit_helper(cmd0::String, arg1; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		    # Also checks if the user wants ONLY the HELP mode
+function gmtsplit_helper(cmd0::String, arg1; kw...)
+	d = init_module(false, kw...)[1]		    # Also checks if the user wants ONLY the HELP mode
+	gmtsplit_helper(cmd0, arg1, d)
+end
+function gmtsplit_helper(cmd0::String, arg1, d::Dict{Symbol, Any})
 	cmd, = parse_common_opts(d, "", [:V_params :bi :bo :di :do :e :f :g :h :i :yx])
 	cmd  = parse_these_opts(cmd, d, [[:A :azim_tol], [:C :course_change], [:D :min_dist :min_distance], [:F :filter],
 	                                 [:N :multi :multifile], [:Q :fields :xyzdh], [:S :dh :dist_head]])

--- a/src/spotter/grdrotater.jl
+++ b/src/spotter/grdrotater.jl
@@ -44,9 +44,11 @@ imshow(Gr, plot=(data=tri_rot,))
 ```
 """
 grdrotater(arg1; kw...) = grdrotater("", arg1; kw...)
-function grdrotater(cmd0::String="", arg1=nothing; kwargs...)
-
-	d = init_module(false, kwargs...)[1]			# Also checks if the user wants ONLY the HELP mode
+function grdrotater(cmd0::String="", arg1=nothing; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
+	grdrotater(cmd0, arg1, d)
+end
+function grdrotater(cmd0::String, arg1, d::Dict{Symbol, Any})
 
 	cmd = parse_common_opts(d, "", [:G :R :V_params :b :d :f :g :h :n :o])[1]
 	cmd = parse_these_opts(cmd, d, [[:A :rot_region], [:E :rotation], [:S :rot_outline_only]])

--- a/src/trend1d.jl
+++ b/src/trend1d.jl
@@ -40,9 +40,11 @@ Parameters
 
 To see the full documentation type: ``@? trend1d``
 """
-function trend1d(cmd0::String="", arg1=nothing; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function trend1d(cmd0::String="", arg1=nothing; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
+	trend1d(cmd0, arg1, d)
+end
+function trend1d(cmd0::String, arg1, d::Dict{Symbol, Any})
 
 	cmd, = parse_common_opts(d, "", [:V_params :b :d :e :f :h :i :w :yx])
 	cmd  = parse_these_opts(cmd, d, [[:C :condition_number], [:I :conf_level :confidence_level], [:F :out :output], [:T :equi_space], [:W :weights]])

--- a/src/trend2d.jl
+++ b/src/trend2d.jl
@@ -38,9 +38,11 @@ Parameters
 
 To see the full documentation type: ``@? trend2d``
 """
-function trend2d(cmd0::String="", arg1=nothing; kwargs...)
-
-	d = init_module(false, kwargs...)[1]		# Also checks if the user wants ONLY the HELP mode
+function trend2d(cmd0::String="", arg1=nothing; kw...)
+	d = init_module(false, kw...)[1]		# Also checks if the user wants ONLY the HELP mode
+	trend2d(cmd0, arg1, d)
+end
+function trend2d(cmd0::String, arg1, d::Dict{Symbol, Any})
 	cmd, = parse_common_opts(d, "", [:V_params :b :d :e :f :h :i :w :yx])
 	cmd  = parse_these_opts(cmd, d, [[:C :condition_number], [:I :conf_level :confidence_level], [:F :out :output],
 	                                 [:N :model :n_model], [:W :weights]])


### PR DESCRIPTION
## Summary
- Split entry points from main logic in analysis/potential/spotter/MB module wrappers so that kwargs are converted to `Dict{Symbol,Any}` via `init_module` in thin wrappers before calling the main function
- Affected modules: gmtgravmag3d, gravfft, gravprisms, grdgravmag3d, grdseamount, grdrotater, spectrum1d, sphdistance, sphinterpolate, sphtriangulate, splitxyz, trend1d, trend2d, mbgetdata, mbimport, mblevitus, mbsvplist

## Test plan
- [x] All `Vd=2` smoke tests pass
- [x] `test_B-GMTs.jl` passes (gmtgravmag3d, grdgravmag3d, gravprisms, grdseamount, gravfft)
- [x] `test_P_a_T.jl` passes (spectrum1d, sphtriangulate, sphinterpolate, sphdistance, splitxyz, trend1d, trend2d)
- [x] `test_GRDs.jl` passes (grdrotater)
- [x] Actual execution tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)