### PR TITLE
Use the same Dict type "Dict{Symbol,Any}" all over a 'd' is passed.

### DIFF
--- a/src/GMT.jl
+++ b/src/GMT.jl
@@ -96,7 +96,7 @@ const DEF_FIG_AXES = Ref{String}(DEF_FIG_AXES_BAK)	# This one may be be changed 
 const DEF_FIG_AXES3 = Ref{String}(DEF_FIG_AXES3_BAK)#		""
 const FIG_MARGIN = Ref{Int}(1)                      # Figure margin in points after convertion by 'psconvert'. Accessible 'margin' common option
 const global CTRL = CTRLstruct(zeros(13), zeros(6), [true], [false],
-                    [:arrows, :bubblechart, :basemap, :band, :clip, :coast, :colorbar, :grdcontour, :hband, :hlines, :inset, :logo, :lines, :grdvector, :plot, :plot3, :quiver, :scatter, :scatter3, :stairs, :text, :vlines, :vband], ["", "", ""], ["", "", "", "   "], ["", ""], ["", ""], [false, true], [C_NULL], [Dict()])
+                    [:arrows, :bubblechart, :basemap, :band, :clip, :coast, :colorbar, :grdcontour, :hband, :hlines, :inset, :logo, :lines, :grdvector, :plot, :plot3, :quiver, :scatter, :scatter3, :stairs, :text, :vlines, :vband], ["", "", ""], ["", "", "", "   "], ["", ""], ["", ""], [false, true], [C_NULL], [Dict{Symbol,Any}()])
 const pocket_call = Ref{Vector{Any}}(Any[nothing, nothing, nothing, nothing, nothing, nothing])# Extracted from CTRL to isolate type instability
 const CTRLshapes = CTRLstruct2(true, true, "")		# Used in sub-module Drawing
 const prj4WGS84 = "+proj=longlat +datum=WGS84 +units=m +no_defs"# This is used in many places
@@ -387,7 +387,7 @@ using .Laszip
 	gmtwrite(t, [0.0 0; 1 1])
 	gmtread(t)
 	gmtread(TESTSDIR * "assets/burro_cenora.jpg")
-	coast(R=:g, proj=:guess, W=(level=1, pen=(2, :green)), savefig=tempname()*".ps")
+	#coast(R=:g, proj=:guess, W=(level=1, pen=(2, :green)), savefig=tempname()*".ps")
 	rm(t)
 	D = mat2ds(rand(3, 3), colnames=["Time", "b", "c"])
 	D.attrib = Dict("Timecol" => "1")

--- a/src/extras/mapsize2region.jl
+++ b/src/extras/mapsize2region.jl
@@ -45,9 +45,9 @@ function mapsize2region(; proj="", scale="", clon=NaN, clat=NaN, width=0, height
 	@assert clon != NaN && clat != NaN "Center longitude and latitude must be specified"
 	@assert width > 0 && height > 0 "Width and height must be positive"
 	@assert contains(scale, ':') "Scale must be in the form of '1:xxxx'"
-	(!isa(proj, StrSymb)) && (proj = parse_J(Dict(:J => proj, :scale => scale), "")[1][4:end];	scale="")	# scale is now in J
-	(bnds != "") && (bnds = parse_R(Dict(:R => bnds), "")[4:end])	# If bnds is not empty, parse it
-	(!isa(scale, StrSymb)) && (scale = parse_Scale(Dict(:S => scale), ""))	# If scale is not a StrSymb, parse it
+	(!isa(proj, StrSymb)) && (proj = parse_J(Dict{Symbol,Any}(:J => proj, :scale => scale), "")[1][4:end];	scale="")	# scale is now in J
+	(bnds != "") && (bnds = parse_R(Dict{Symbol,Any}(:R => bnds), "")[4:end])	# If bnds is not empty, parse it
+	(!isa(scale, StrSymb)) && (scale = parse_Scale(Dict{Symbol,Any}(:S => scale), ""))	# If scale is not a StrSymb, parse it
 	(bnds == "" && proj == "m" || startswith(proj, "merc") || startswith(proj, "Merc")) && (bnds="-180/180/-85/85")	# Default bounds for Mercator
 	opt_R, opt_J = mapsize2region(string(proj), scale, Float64(clon), Float64(clat), Float64(width), Float64(height), bnds)
 	(plot != 0) && coast(R=opt_R, J=opt_J, shore=true, show=true, Vd=1)

--- a/src/extras/seismicity.jl
+++ b/src/extras/seismicity.jl
@@ -136,7 +136,7 @@ function seismicity(; starttime::Union{DateTime, String}="", endtime::Union{Date
 	plot!(D[:,1:4]; ml="faint", S=opt_S, C=C, show=see, Vd=Vd, d...)
 	d = CTRL.pocket_d[1]
 	d[:show] = show
-	ms = (_size !== nothing) ? parse_opt_S(Dict(:size => _size), [3., 4, 5, 6, 7, 8, 9])[1] : [3., 4, 5, 6, 7, 8, 9] .* 0.02
+	ms = (_size !== nothing) ? parse_opt_S(Dict{Symbol,Any}(:size => _size), [3., 4, 5, 6, 7, 8, 9])[1] : [3., 4, 5, 6, 7, 8, 9] .* 0.02
 	st = (starttime != "") ? string(starttime) : string(Date(now() - Dates.Day(30)))
 	et = (endtime != "") ? string(endtime) : string(Date(now()))
 	legend && seislegend(; first=false, title="From "*st*" to "*et, cmap=C, mags=ms, pos="JBC+o0/1c+w12c/2.3c", d...)

--- a/src/extras/weather.jl
+++ b/src/extras/weather.jl
@@ -264,7 +264,7 @@ function ecmwf(source::Symbol=:reanalysis; filename="", cb::Bool=false, dataset=
 			last = (region == "") ? "\n" : ",\n"	# Having an extra comma at the end of the line is a json syntax error
 			params *= "\"download_format\": \"unarchived\"" * last
 			if (region != "")		# The region is provided by parse_R() as a string like " -R58/6/55/9" (N/W/S/E)
-				optR = split(parse_R(Dict(:R => region), "")[1], '/')
+				optR = split(parse_R(Dict{Symbol,Any}(:R => region), "")[1], '/')
 				params *= "\"area\": [" * optR[1][4:end] * ", " * optR[4] * ", " * optR[2] * ", " * optR[3] * "]\n"
 			end
 			params = "{\"product_type\": [\"reanalysis\"],\n" * params * "}"

--- a/src/gdal_utils.jl
+++ b/src/gdal_utils.jl
@@ -957,7 +957,8 @@ Write a MxNxP `cube` object to disk as a multilayered file.
 """
 function gdalwrite(fname::AbstractString, data, optsP=String[]; opts=String[], kw...)
 	(fname == "") && error("Output file name is missing.")
-	(isempty(optsP) && !isempty(opts)) && (optsP = opts)		# Accept either Positional or KW argument
+	(isempty(optsP) && !isempty(opts)) && (optsP = opts)			# Accept either Positional or KW argument
+	isa(optsP, AbstractString) && (optsP = gdal_opts2vec(optsP))	# Guarantied to return a Vector{String}
 	ds = Gdal.get_gdaldataset(data, optsP)[1]
 	if (Gdal.GDALGetRasterCount(ds.ptr) >= 1)
 		gdaltranslate(ds, optsP; dest=fname, kw...)

--- a/src/gmt_types.jl
+++ b/src/gmt_types.jl
@@ -365,17 +365,20 @@ end
 mutable struct wrapGrids
 	fname::String
 	grd::GMTgrid
+	img::GMTimage
 	function wrapGrids(arg1, arg2)
-		if     (arg1 !== "")         new(arg1, GMTgrid())
-		elseif (isa(arg2, GMTgrid))  new("", arg2)
-		elseif (isa(arg2, Matrix{<:Real}))        new("", mat2grid(arg2))
-		elseif (arg1 === "" && arg2 === nothing)  new("", GMTgrid())	# Less usual case in grdlandmask where only kwargs are given
+		tg, ti  = GMTgrid(), GMTimage()
+		if     (arg1 !== "")         new(arg1, tg, ti)
+		elseif (isa(arg2, GMTgrid))  new("", arg2, ti)
+		elseif (isa(arg2, GMTimage)) new("", tg, arg2)
+		elseif (isa(arg2, Matrix{<:Real}))        new("", mat2grid(arg2), ti)
+		elseif (arg1 === "" && arg2 === nothing)  new("", tg, ti)	# Less usual case in grdlandmask where only kwargs are given
 		else   error("Unknown types ($(typeof(arg1)), $(typeof(arg2))) in wrapGrids")
 		end
 	end
 end
 function unwrapGrids(w::wrapGrids)
-	return w.fname, !isempty(w.grd) ? w.grd : nothing
+	return w.fname, !isempty(w.grd) ? w.grd : !isempty(w.img) ? w.img : nothing
 end
 
 #=

--- a/src/imshow.jl
+++ b/src/imshow.jl
@@ -180,7 +180,7 @@ function imshow(arg1::GItype; kw...)
 			# This is a (poor) pach for a GMT bug that screws when plotting CPTs on the sides.
 			margin = "0"
 			if ((val = find_in_dict(d, [:colorbar], false)[1]) !== nothing)
-				tv = add_opt_module(Dict(:colorbar => val))
+				tv = add_opt_module(Dict{Symbol,Any}(:colorbar => val))
 				t2 = scan_opt(tv[1], "-D")
 				t2 = replace(t2, "JMR" => "JMC")
 				!contains(t2, "+o") && (t2 *= "+o$(_w/2 + 0.3)/0")

--- a/src/marker_name.jl
+++ b/src/marker_name.jl
@@ -1,5 +1,5 @@
 # Put this code in a separate file to permit access from future GMT_base module
-function get_marker_name(d::Dict, arg1, symbs::Vector{Symbol}, is3D::Bool, del::Bool=true)
+function get_marker_name(d::Dict, @nospecialize(arg1), symbs::Vector{Symbol}, is3D::Bool, del::Bool=true)
 	marca::String = "";		N = 0
 	for symb in symbs
 		if (haskey(d, symb))
@@ -118,7 +118,7 @@ function helper_markers(opt::String, ext, arg1::GMTdataset, N::Int, cst::Bool)
 	if (size(ext,2) == N)	# Here ARG1 is supposed to be a matrix that will be extended.
 		S = Symbol(opt)
 		t = arg1.data	# Because we need to passa matrix to this method of add_opt()
-		marca, t = add_opt(add_opt, (Dict(S => (par=ext,)), opt, "", [S]), (par="|",), true, t)
+		marca, t = add_opt(add_opt, (Dict{Symbol,Any}(S => (par=ext,)), opt, "", [S]), (par="|",), true, t)
 		arg1.data = t;		add2ds!(arg1)
 	elseif (cst && length(ext) == 1)
 		marca = opt * "-" * string(ext)::String

--- a/src/pcolor.jl
+++ b/src/pcolor.jl
@@ -211,7 +211,7 @@ function pcolor(G::GMTgrid, first::Bool, d::Dict{Symbol,Any})
 	if (find_in_dict(d, [:T :no_interp :tiles])[1] === nothing)	# If no -T, make one here
 		opt_T = "+s"
 		if ((val = find_in_dict(d, [:outline])[1]) !== nothing)	# -T+o is bugged for line styles
-			opt_T *= "+o" * add_opt_pen(Dict(:outline => val), [:outline])
+			opt_T *= "+o" * add_opt_pen(Dict{Symbol,Any}(:outline => val), [:outline])
 		end
 		d[:T] = opt_T
 	end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -840,8 +840,8 @@ function fill_between(arg1, arg2, first::Bool, d::Dict{Symbol, Any})
 	_D2 = one_array ? mat2ds(D1, (:,[1,3])) : D2		# Put second line in a unique var
 
 	if (border > 0)										# Plot a white border
-		one_array ? common_plot_xyz("", [mat2ds(D1, (:,[1,2])), _D2], "lines", false, false, Dict(:W => "$(border),white", :Vd => Vd)) :
-		            common_plot_xyz("", [D1, _D2], "lines", false, false, Dict(:W => "$(border),white", :Vd => Vd))
+		one_array ? common_plot_xyz("", [mat2ds(D1, (:,[1,2])), _D2], "lines", false, false, Dict{Symbol,Any}(:W => "$(border),white", :Vd => Vd)) :
+		            common_plot_xyz("", [D1, _D2], "lines", false, false, Dict{Symbol,Any}(:W => "$(border),white", :Vd => Vd))
 	end
 
 	do_stairs && (d[:stairs_step] = :pre)

--- a/src/potential/gmtgravmag3d.jl
+++ b/src/potential/gmtgravmag3d.jl
@@ -80,9 +80,9 @@ function _gravmag3d_helper(arg1, d::Dict{Symbol,Any})
 	elseif ((val = find_in_dict(d, [:Ts :stl :STL], true, "String (file name)")[1]) !== nothing && val != "")  opt = " -Ts"
 	elseif ((val = find_in_dict(d, [:M :body], false, "String | NamedTuple")[1]) !== nothing && val != "")
 		if (isa(val, Tuple))
-			cmd = add_opt(Dict(:body => val[1]), cmd, "M", [:M :body], (shape="+s", params=","))
+			cmd = add_opt(Dict{Symbol,Any}(:body => val[1]), cmd, "M", [:M :body], (shape="+s", params=","))
 			for n = 2:numel(val)
-				cmd = add_opt(Dict(:body => val[n]), cmd, "", [:M :body], (shape="+s", params=","))
+				cmd = add_opt(Dict{Symbol,Any}(:body => val[n]), cmd, "", [:M :body], (shape="+s", params=","))
 			end
 			delete!(d, [:M :body])
 		else

--- a/src/pscoast.jl
+++ b/src/pscoast.jl
@@ -265,7 +265,7 @@ function parse_dcw(cmd::String, val::Tuple)::String
 	for k = 1:numel(val)
 		if (isa(val[k], NamedTuple) || isa(val[k], Dict))
 			isa(val[k], AbstractDict) && (val[k] = Base.invokelatest(dict2nt, val[k]))
-			cmd *= add_opt(Dict(:DCW => val[k]), "", "E", [:DCW], (country="", name="", continent="=", pen=("+p", add_opt_pen),
+			cmd *= add_opt(Dict{Symbol,Any}(:DCW => val[k]), "", "E", [:DCW], (country="", name="", continent="=", pen=("+p", add_opt_pen),
 			                                                       fill=("+g", add_opt_fill), file=("+f"), inside=("_+c"), outside=("_+C"), adjust_r=("+r", arg2str), adjust_R=("+R", arg2str), adjust_e=("+e", arg2str), headers=("_+z")))
 		elseif (isa(val[k], Tuple))
 			cmd *= parse_dcw(val[k])
@@ -284,7 +284,7 @@ function parse_dcw(val::Tuple)::String
 		else                     t *= string(val[2])
 		end
 		if (length(val) > 2)
-			if (isa(val[3], Tuple))  t *= add_opt_fill("+g", Dict(fill => val[3]), [:fill])
+			if (isa(val[3], Tuple))  t *= add_opt_fill("+g", Dict{Symbol,Any}(fill => val[3]), [:fill])
 			else                     t *= string(val[3])
 			end
 		end

--- a/src/pslegend.jl
+++ b/src/pslegend.jl
@@ -69,7 +69,7 @@ function legend(cmd0::String, arg1, O::Bool, K::Bool, d::Dict{Symbol, Any})
 		# Must also recreate a NT if any of 'fontsize' or 'font' is present in 'd' (because of how digests_legend_bag works)
 		((val = find_in_dict(d, [:fontsize])[1]) !== nothing) && (d[:leg] = (fontsize=val,))
 		((val = find_in_dict(d, [:font])[1]) !== nothing) && (haskey(d, :leg) ? d[:leg] = (fontsize=d[:leg], font=val) : d[:leg] = (font=val,))
-		((val = find_in_dict(d, [:pos :position])[1]) !== nothing) && (LEGEND_TYPE[].optsDict = Dict(:pos => val))
+		((val = find_in_dict(d, [:pos :position])[1]) !== nothing) && (LEGEND_TYPE[].optsDict = Dict{Symbol,Any}(:pos => val))
 
 		digests_legend_bag(d)	# It's over now, lets show up (or not) and return
 		return (do_show || figname != "") ? showfig(show=do_show, savefig=figname) : nothing

--- a/src/subplot.jl
+++ b/src/subplot.jl
@@ -213,7 +213,7 @@ function mura_arg(arg)::Dict
 	if (isa(arg, Tuple{Tuple, Real}))  arg = (arg[1], (arg[2],))  end	# This looks terribly type instable
 	# Need first case because for example dims=(panels=((2,4),(2.5,5,1.25)),) shows up here only as
 	# arg = ((2, 4), (2.5, 5, 1.25)) because this function was called from within add_opt()
-	if (isa(arg, Tuple{Tuple, Tuple}))  d = Dict(:panels => arg)
+	if (isa(arg, Tuple{Tuple, Tuple}))  d = Dict{Symbol,Any}(:panels => arg)
 	else                                d = (isa(arg, NamedTuple)) ? nt2dict(arg) : arg
 	end
 	d

--- a/src/trend1d.jl
+++ b/src/trend1d.jl
@@ -53,12 +53,12 @@ function trend1d(cmd0::String, arg1, d::Dict{Symbol, Any})
 		# can only be used once and in the last NT element. Hence, we must split execution in two parts.
 		opt_N = " -N"
 		for k = 1:length(val)-1
-			t = add_opt(Dict(:N => val[k]), "", "N", [:N],
+			t = add_opt(Dict{Symbol,Any}(:N => val[k]), "", "N", [:N],
 			            (polynome=("p", arg2str, 1), polynomal=("p", arg2str, 1), fourier=("f", arg2str, 1), cosine=("c", arg2str, 1), sine=("s", arg2str, 1), single="_!"))
 			contains(t, "!") && (t = replace(t, "!" => ""); t = replace(t, t[4] => uppercase(t[4])))
 			opt_N *= t[4:end] * ","
 		end
-		t = add_opt(Dict(:N => val[end]), "", "N", [:N],
+		t = add_opt(Dict{Symbol,Any}(:N => val[end]), "", "N", [:N],
 		            (polynome=("p", arg2str, 1), polynomal=("p", arg2str, 1), fourier=("f", arg2str, 1), cosine=("c", arg2str, 1), sine=("s", arg2str, 1), length="+l", origin="+o", robust="+r", single="_!"))
 		contains(t, "!") && (t = replace(t, "!" => ""); t = replace(t, t[4] => uppercase(t[4])))
 		opt_N *= t[4:end]

--- a/test/test_PSs.jl
+++ b/test/test_PSs.jl
@@ -229,10 +229,10 @@ ternary(d, R="0/100/0/100/0/100", B="afg", contour=(annot=20, cont=10), clockwis
 ternary(d, R="0/100/0/100/0/100", B="afg", contourf=true)
 ternary(d, R="0/100/0/100/0/100", B="afg", image=true, contour=true, Vd=dbg2)
 ternary()
-d = Dict(:a=>"", :frame => (annot=:a, grid=8, alabel=:a, blabel=:b, clabel=:c, suffix=" %"));
+d = Dict{Symbol,Any}(:a=>"", :frame => (annot=:a, grid=8, alabel=:a, blabel=:b, clabel=:c, suffix=" %"));
 GMT.parse_B4ternary!(d);
 @test d[:B] == " -Baag8+u\" %\"+la -Bbag8+u\" %\"+lb -Bcag8+u\" %\"+lc"
-d = Dict(:a=>"", :labels => (:a, :b, :c));
+d = Dict{Symbol,Any}(:a=>"", :labels => (:a, :b, :c));
 GMT.parse_B4ternary!(d);
 @test d[:B] == " -Baafg+la -Bbafg+lb -Bcafg+lc"
 

--- a/test/test_common_opts.jl
+++ b/test/test_common_opts.jl
@@ -304,7 +304,7 @@
 	@test_throws ErrorException("Bad family type") GMT.GMT_Alloc_Segment(C_NULL, -1, 0, 0, "", C_NULL)
 	#@test_throws ErrorException("Unknown family type") GMT.GMT_Create_Data(C_NULL, -99, 0, 0)
 	@test_throws ErrorException("Expected a PS structure for input") GMT.ps_init(C_NULL, 0, 0)
-	@test_throws ErrorException("size of x,y vectors incompatible with 2D array size") GMT.grdimg_hdr_xy(rand(3,3), 0, Float64[], [1 2], [1])
+	@test_throws ErrorException("size of x,y vectors incompatible with 2D array size") GMT.grdimg_hdr_xy(rand(3,3), 0, Float64[], [1.0, 2], [1.0])
 	GMT.strncmp("abcd", "ab", 2)
 	GMT.parse_proj((name="blabla",center=(0,0)))
 


### PR DESCRIPTION
This forces only one type in many functions and thus reduces the multiple compilations.

Shelter grdimage.