### PR TITLE
Add an alternative way of setting which version of Ghostscript to use.

### DIFF
--- a/src/GMT.jl
+++ b/src/GMT.jl
@@ -49,9 +49,34 @@ if ((!(@isdefined have_jll) || have_jll == 1) && get(ENV, "SYSTEMWIDE_GMT", "") 
 	const GMTver = VersionNumber(t[1])
 	const GMTdevdate = (length(t) > 1) ? Date(t[end], dateformat"y.m.d") : Date("0001-01-01")# For DEV versions
 	const GMTuserdir = [readlines(`$(GMT_jll.gmt()) "--show-userdir"`)[1]]
-	const GSbin = Ghostscript_jll.gs()[1]
 	const GMTbin = GMT_jll.gmt()[1]
 	const isJLL = true
+	gs_path, _libgs = "", ""
+	gsSYS = string(get(ENV, "SYSTEMWIDE_GS", ""))
+	if (gsSYS !== "")
+		if Sys.iswindows()
+			if (contains(gsSYS, ':'))		# A path for sure. Believe it ... for now
+				gs_path = gsSYS
+				_libgs = joinpath(gs_path, "gsdll64.dll")
+			else
+				try
+					t2 = string(readchomp(`where gswin64c`))
+					ind = findfirst(".exe", t2)
+					gs_path = t2[1:ind[end]]
+					_libgs = t2[1:ind[1]-9] * "//gsdll64.dll"
+				catch
+				end
+			end
+			(gs_path === "") && println("\n\nNo Ghostscript system wide installation found. Resorting to the JLL one\n\n")
+		else								# Assume it is Unix
+			gs_path = string(readchomp(`which gs`))
+			_libgs = split(readlines(pipeline(`ldd $(gs_path)`, `grep libgs`))[1])[3]
+		end
+	end
+	const GSbin = (gs_path === "") ? Ghostscript_jll.gs()[1] : gs_path
+	const gslib = (gs_path === "") ? libgs : _libgs
+
+	#const GSbin = Ghostscript_jll.gs()[1]
 	fname = joinpath(GMTuserdir[1], "ghost_jll_path.txt")
 	!isdir(GMTuserdir[1]) && mkdir(GMTuserdir[1])	# When installing on a clean no GMT sys, ~/.gmt doesn't exist
 	open(fname, "w") do f
@@ -61,7 +86,7 @@ if ((!(@isdefined have_jll) || have_jll == 1) && get(ENV, "SYSTEMWIDE_GMT", "") 
 	libpostscriptlight = joinpath(pato, replace(fname, "gmt" => "postscriptlight"))
 else
 	const isJLL = false
-	const GMTver, libgmt, libpostscriptlight, libgs, libgdal, libproj, GMTuserdir, GMTbin = _GMTver, _libgmt, _libpostscriptlight, _libgs, _libgdal, _libproj, [userdir], "gmt"
+	const GMTver, libgmt, libpostscriptlight, gslib, libgdal, libproj, GMTuserdir, GMTbin = _GMTver, _libgmt, _libpostscriptlight, _libgs, _libgdal, _libproj, [userdir], "gmt"
 	const GMTdevdate = Date(devdate, dateformat"y.m.d")		# 'devdate' comes from reading 'deps.jl'
 end
 

--- a/src/ghost/ghost_funs.jl
+++ b/src/ghost/ghost_funs.jl
@@ -19,10 +19,6 @@
 	└────────────┴──────────────────────────────────────────┴───────────────────────────────────────────┘
 """
 
-# Include libghostscript.jl in GMT's own scope so that all ccalls use GMT's `libgs`,
-# not Ghostscript_jll's libgs-9.dll which lacks the bbox device.
-#include(joinpath(dirname(Base.find_package("Ghostscript")), "libghostscript.jl"))
-
 # ── Display format flags (gdevdsp.h) ─────────────────────────────────────────
 # RGB 24-bit, no alpha, big-endian, top row first = 0x00000804
 const _GS_FMT_RGB24   = 0x00000004 | 0x00000800
@@ -154,8 +150,6 @@ function _gs_session(args::Vector{String}, action::Function; setup::Function=(_)
 			rc < 0 && error("gsapi_set_display_callback failed: $rc")
 		end
 		setup(inst)
-		#args_c = [Base.cconvert(Cstring, s) for s in args]
-		#argv   = [Base.unsafe_convert(Cstring, s) for s in args_c]
 		GC.@preserve display_cb begin
 			rc = gsapi_init_with_args(inst, Cint(length(args)), args)
 			rc < 0 && error("gsapi_init_with_args failed: $rc")
@@ -603,8 +597,7 @@ function psview(ps_data::Union{String, AbstractVector{UInt8}}; dpi::Int=300)
 	# Returns RECT {left, top, right, bottom} as four Int32.
 	workrect = zeros(Int32, 4)
 	GC.@preserve workrect begin
-		ccall((:SystemParametersInfoW, "user32"), Bool,
-			  (UInt32, UInt32, Ptr{Int32}, UInt32),
+		ccall((:SystemParametersInfoW, "user32"), Bool, (UInt32, UInt32, Ptr{Int32}, UInt32),
 			  UInt32(0x0030), UInt32(0), pointer(workrect), UInt32(0))
 	end
 	wa_x = Int(workrect[1]);  wa_y = Int(workrect[2])

--- a/src/ghost/libghostscript.jl
+++ b/src/ghost/libghostscript.jl
@@ -40,141 +40,135 @@ struct gsapi_fs_t
 	open_handle::Ptr{Cvoid}
 end
 
-function gsapi_revision(pr, len)
-	ccall((:gsapi_revision, libgs), Cint, (Ptr{gsapi_revision_s}, Cint), pr, len)
-end
+gsapi_revision(pr, len) = ccall((:gsapi_revision, gslib), Cint, (Ptr{gsapi_revision_s}, Cint), pr, len)
 
 function gsapi_new_instance(pinstance, caller_handle)
-	ccall((:gsapi_new_instance, libgs), Cint, (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}), pinstance, caller_handle)
+	ccall((:gsapi_new_instance, gslib), Cint, (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}), pinstance, caller_handle)
 end
 
-function gsapi_delete_instance(instance)
-	ccall((:gsapi_delete_instance, libgs), Cvoid, (Ptr{Cvoid},), instance)
-end
+gsapi_delete_instance(instance) = ccall((:gsapi_delete_instance, gslib), Cvoid, (Ptr{Cvoid},), instance)
 
 function gsapi_set_stdio(instance, stdin_fn, stdout_fn, stderr_fn)
-	ccall((:gsapi_set_stdio, libgs), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), instance, stdin_fn, stdout_fn, stderr_fn)
+	ccall((:gsapi_set_stdio, gslib), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), instance, stdin_fn, stdout_fn, stderr_fn)
 end
 
 function gsapi_set_stdio_with_handle(instance, stdin_fn, stdout_fn, stderr_fn, caller_handle)
-	ccall((:gsapi_set_stdio_with_handle, libgs), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+	ccall((:gsapi_set_stdio_with_handle, gslib), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
 		instance, stdin_fn, stdout_fn, stderr_fn, caller_handle)
 end
 
-function gsapi_set_poll(instance, poll_fn)
-	ccall((:gsapi_set_poll, libgs), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), instance, poll_fn)
-end
+gsapi_set_poll(instance, poll_fn) = ccall((:gsapi_set_poll, gslib), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), instance, poll_fn)
 
 function gsapi_set_poll_with_handle(instance, poll_fn, caller_handle)
-	ccall((:gsapi_set_poll_with_handle, libgs), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), instance, poll_fn, caller_handle)
+	ccall((:gsapi_set_poll_with_handle, gslib), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), instance, poll_fn, caller_handle)
 end
 
 function gsapi_set_display_callback(instance, callback)
-	ccall((:gsapi_set_display_callback, libgs), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), instance, callback)
+	ccall((:gsapi_set_display_callback, gslib), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), instance, callback)
 end
 
 function gsapi_register_callout(instance, callout, callout_handle)
-	ccall((:gsapi_register_callout, libgs), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), instance, callout, callout_handle)
+	ccall((:gsapi_register_callout, gslib), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), instance, callout, callout_handle)
 end
 
 function gsapi_deregister_callout(instance, callout, callout_handle)
-	ccall((:gsapi_deregister_callout, libgs), Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), instance, callout, callout_handle)
+	ccall((:gsapi_deregister_callout, gslib), Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), instance, callout, callout_handle)
 end
 
 function gsapi_set_default_device_list(instance, list, listlen)
-	ccall((:gsapi_set_default_device_list, libgs), Cint, (Ptr{Cvoid}, Cstring, Cint), instance, list, listlen)
+	ccall((:gsapi_set_default_device_list, gslib), Cint, (Ptr{Cvoid}, Cstring, Cint), instance, list, listlen)
 end
 
 function gsapi_get_default_device_list(instance, list, listlen)
-	ccall((:gsapi_get_default_device_list, libgs), Cint, (Ptr{Cvoid}, Ptr{Cstring}, Ptr{Cint}), instance, list, listlen)
+	ccall((:gsapi_get_default_device_list, gslib), Cint, (Ptr{Cvoid}, Ptr{Cstring}, Ptr{Cint}), instance, list, listlen)
 end
 
 function gsapi_set_arg_encoding(instance, encoding)
-	ccall((:gsapi_set_arg_encoding, libgs), Cint, (Ptr{Cvoid}, Cint), instance, encoding)
+	ccall((:gsapi_set_arg_encoding, gslib), Cint, (Ptr{Cvoid}, Cint), instance, encoding)
 end
 
 function gsapi_init_with_args(instance, argc, argv)
-	ccall((:gsapi_init_with_args, libgs), Cint, (Ptr{Cvoid}, Cint, Ptr{Cstring}), instance, argc, argv)
+	ccall((:gsapi_init_with_args, gslib), Cint, (Ptr{Cvoid}, Cint, Ptr{Cstring}), instance, argc, argv)
 end
 
 function gsapi_init_with_argsA(instance, argc, argv)
-	ccall((:gsapi_init_with_argsA, libgs), Cint, (Ptr{Cvoid}, Cint, Ptr{Cstring}), instance, argc, argv)
+	ccall((:gsapi_init_with_argsA, gslib), Cint, (Ptr{Cvoid}, Cint, Ptr{Cstring}), instance, argc, argv)
 end
 
 function gsapi_init_with_argsW(instance, argc, argv)
-	ccall((:gsapi_init_with_argsW, libgs), Cint, (Ptr{Cvoid}, Cint, Ptr{Ptr{Cwchar_t}}), instance, argc, argv)
+	ccall((:gsapi_init_with_argsW, gslib), Cint, (Ptr{Cvoid}, Cint, Ptr{Ptr{Cwchar_t}}), instance, argc, argv)
 end
 
 function gsapi_run_string_begin(instance, user_errors, pexit_code)
-	ccall((:gsapi_run_string_begin, libgs), Cint, (Ptr{Cvoid}, Cint, Ptr{Cint}), instance, user_errors, pexit_code)
+	ccall((:gsapi_run_string_begin, gslib), Cint, (Ptr{Cvoid}, Cint, Ptr{Cint}), instance, user_errors, pexit_code)
 end
 
 function gsapi_run_string_continue(instance, str, length, user_errors, pexit_code)
-	ccall((:gsapi_run_string_continue, libgs), Cint, (Ptr{Cvoid}, Ptr{UInt8}, Cuint, Cint, Ptr{Cint}), instance, str, length, user_errors, pexit_code)
+	ccall((:gsapi_run_string_continue, gslib), Cint, (Ptr{Cvoid}, Ptr{UInt8}, Cuint, Cint, Ptr{Cint}), instance, str, length, user_errors, pexit_code)
 end
 
 function gsapi_run_string_end(instance, user_errors, pexit_code)
-	ccall((:gsapi_run_string_end, libgs), Cint, (Ptr{Cvoid}, Cint, Ptr{Cint}), instance, user_errors, pexit_code)
+	ccall((:gsapi_run_string_end, gslib), Cint, (Ptr{Cvoid}, Cint, Ptr{Cint}), instance, user_errors, pexit_code)
 end
 
 function gsapi_run_string_with_length(instance, str, length, user_errors, pexit_code)
-	ccall((:gsapi_run_string_with_length, libgs), Cint, (Ptr{Cvoid}, Ptr{UInt8}, Cuint, Cint, Ptr{Cint}), instance, str, length, user_errors, pexit_code)
+	ccall((:gsapi_run_string_with_length, gslib), Cint, (Ptr{Cvoid}, Ptr{UInt8}, Cuint, Cint, Ptr{Cint}), instance, str, length, user_errors, pexit_code)
 end
 
 function gsapi_run_string(instance, str, user_errors, pexit_code)
-	ccall((:gsapi_run_string, libgs), Cint, (Ptr{Cvoid}, Cstring, Cint, Ptr{Cint}), instance, str, user_errors, pexit_code)
+	ccall((:gsapi_run_string, gslib), Cint, (Ptr{Cvoid}, Cstring, Cint, Ptr{Cint}), instance, str, user_errors, pexit_code)
 end
 
 function gsapi_run_file(instance, file_name, user_errors, pexit_code)
-	ccall((:gsapi_run_file, libgs), Cint, (Ptr{Cvoid}, Cstring, Cint, Ptr{Cint}), instance, file_name, user_errors, pexit_code)
+	ccall((:gsapi_run_file, gslib), Cint, (Ptr{Cvoid}, Cstring, Cint, Ptr{Cint}), instance, file_name, user_errors, pexit_code)
 end
 
 function gsapi_run_fileA(instance, file_name, user_errors, pexit_code)
-	ccall((:gsapi_run_fileA, libgs), Cint, (Ptr{Cvoid}, Cstring, Cint, Ptr{Cint}), instance, file_name, user_errors, pexit_code)
+	ccall((:gsapi_run_fileA, gslib), Cint, (Ptr{Cvoid}, Cstring, Cint, Ptr{Cint}), instance, file_name, user_errors, pexit_code)
 end
 
 function gsapi_run_fileW(instance, file_name, user_errors, pexit_code)
-	ccall((:gsapi_run_fileW, libgs), Cint, (Ptr{Cvoid}, Ptr{Cwchar_t}, Cint, Ptr{Cint}), instance, file_name, user_errors, pexit_code)
+	ccall((:gsapi_run_fileW, gslib), Cint, (Ptr{Cvoid}, Ptr{Cwchar_t}, Cint, Ptr{Cint}), instance, file_name, user_errors, pexit_code)
 end
 
-gsapi_exit(instance) = ccall((:gsapi_exit, libgs), Cint, (Ptr{Cvoid},), instance)
+gsapi_exit(instance) = ccall((:gsapi_exit, gslib), Cint, (Ptr{Cvoid},), instance)
 
 function gsapi_set_param(instance, param, value, type)
-	ccall((:gsapi_set_param, libgs), Cint, (Ptr{Cvoid}, Cstring, Ptr{Cvoid}, gs_set_param_type), instance, param, value, type)
+	ccall((:gsapi_set_param, gslib), Cint, (Ptr{Cvoid}, Cstring, Ptr{Cvoid}, gs_set_param_type), instance, param, value, type)
 end
 
 function gsapi_get_param(instance, param, value, type)
-	ccall((:gsapi_get_param, libgs), Cint, (Ptr{Cvoid}, Cstring, Ptr{Cvoid}, gs_set_param_type), instance, param, value, type)
+	ccall((:gsapi_get_param, gslib), Cint, (Ptr{Cvoid}, Cstring, Ptr{Cvoid}, gs_set_param_type), instance, param, value, type)
 end
 
 function gsapi_enumerate_params(instance, iterator, key, type)
-	ccall((:gsapi_enumerate_params, libgs), Cint, (Ptr{Cvoid}, Ptr{Ptr{Cvoid}}, Ptr{Cstring}, Ptr{gs_set_param_type}), instance, iterator, key, type)
+	ccall((:gsapi_enumerate_params, gslib), Cint, (Ptr{Cvoid}, Ptr{Ptr{Cvoid}}, Ptr{Cstring}, Ptr{gs_set_param_type}), instance, iterator, key, type)
 end
 
 function gsapi_add_control_path(instance, type, path)
-	ccall((:gsapi_add_control_path, libgs), Cint, (Ptr{Cvoid}, Cint, Cstring), instance, type, path)
+	ccall((:gsapi_add_control_path, gslib), Cint, (Ptr{Cvoid}, Cint, Cstring), instance, type, path)
 end
 
 function gsapi_remove_control_path(instance, type, path)
-	ccall((:gsapi_remove_control_path, libgs), Cint, (Ptr{Cvoid}, Cint, Cstring), instance, type, path)
+	ccall((:gsapi_remove_control_path, gslib), Cint, (Ptr{Cvoid}, Cint, Cstring), instance, type, path)
 end
 
 function gsapi_purge_control_paths(instance, type)
-	ccall((:gsapi_purge_control_paths, libgs), Cvoid, (Ptr{Cvoid}, Cint), instance, type)
+	ccall((:gsapi_purge_control_paths, gslib), Cvoid, (Ptr{Cvoid}, Cint), instance, type)
 end
 
 function gsapi_activate_path_control(instance, enable)
-	ccall((:gsapi_activate_path_control, libgs), Cvoid, (Ptr{Cvoid}, Cint), instance, enable)
+	ccall((:gsapi_activate_path_control, gslib), Cvoid, (Ptr{Cvoid}, Cint), instance, enable)
 end
 
 function gsapi_is_path_control_active(instance)
-	ccall((:gsapi_is_path_control_active, libgs), Cint, (Ptr{Cvoid},), instance)
+	ccall((:gsapi_is_path_control_active, gslib), Cint, (Ptr{Cvoid},), instance)
 end
 
 function gsapi_add_fs(instance, fs, secret)
-	ccall((:gsapi_add_fs, libgs), Cint, (Ptr{Cvoid}, Ptr{gsapi_fs_t}, Ptr{Cvoid}), instance, fs, secret)
+	ccall((:gsapi_add_fs, gslib), Cint, (Ptr{Cvoid}, Ptr{gsapi_fs_t}, Ptr{Cvoid}), instance, fs, secret)
 end
 
 function gsapi_remove_fs(instance, fs, secret)
-	ccall((:gsapi_remove_fs, libgs), Cvoid, (Ptr{Cvoid}, Ptr{gsapi_fs_t}, Ptr{Cvoid}), instance, fs, secret)
+	ccall((:gsapi_remove_fs, gslib), Cvoid, (Ptr{Cvoid}, Ptr{gsapi_fs_t}, Ptr{Cvoid}), instance, fs, secret)
 end


### PR DESCRIPTION
The idea is to be able to escape the JLL grip.